### PR TITLE
Configure azure pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ variables:
 
 steps:
 - script: dotnet build src/NewRelic.Telemetry.Sdk.sln --configuration $(buildConfiguration)
-  displayName: 'Build (configuration=$(buildConfiguration)'
+  displayName: 'Build (configuration=$(buildConfiguration))'
 
 - script: dotnet test src/NewRelic.Telemetry.Sdk.Tests --no-build --no-restore --configuration $(buildConfiguration) --logger trx
   displayName: 'Run tests'


### PR DESCRIPTION
* Runs tests without building projects again
* Uses windows image for builds
* Publishes build artifacts
* Adds NuGet package publish step that runs when `pushNupkg=true`