### PR TITLE
DOTNET-4451 - Prevent Empty ParentID on top-level spans

### DIFF
--- a/src/NewRelic.Telemetry/Spans/Span.cs
+++ b/src/NewRelic.Telemetry/Spans/Span.cs
@@ -14,6 +14,26 @@ namespace NewRelic.Telemetry.Spans
         /// </summary>
         public string Id { get; internal set; }
 
+        [IgnoreDataMember]
+        public string ParentId
+        {
+            get
+            {
+                if (Attributes == null)
+                {
+                    return null;
+                }
+
+                if (Attributes.TryGetValue(SpanBuilder.attribName_ParentID, out var parentId))
+                {
+                    return parentId?.ToString();
+                }
+
+                return null;
+            }
+        }
+
+
         /// <summary>
         /// Identifies this span as a component of a trace/operation.
         /// </summary>

--- a/src/NewRelic.Telemetry/Spans/SpanBuilder.cs
+++ b/src/NewRelic.Telemetry/Spans/SpanBuilder.cs
@@ -9,11 +9,11 @@ namespace NewRelic.Telemetry.Spans
     /// </summary>
     public class SpanBuilder
     {
-        private const string attribName_ServiceName = "service.name";
-        private const string attribName_DurationMs = "duration.ms";
-        private const string attribName_Name = "name";
-        private const string attribName_ParentID = "parent.id";
-        private const string attribName_Error = "error";
+        internal const string attribName_ServiceName = "service.name";
+        internal const string attribName_DurationMs = "duration.ms";
+        internal const string attribName_Name = "name";
+        internal const string attribName_ParentID = "parent.id";
+        internal const string attribName_Error = "error";
 
         /// <summary>
         /// Creates a new SpanBuilder with a unique SpanId Identifier.

--- a/src/OpenTelemetry.Exporter.NewRelic.Tests/SpanConverterTests.cs
+++ b/src/OpenTelemetry.Exporter.NewRelic.Tests/SpanConverterTests.cs
@@ -117,6 +117,18 @@ namespace OpenTelemetry.Exporter.NewRelic.Tests
         }
 
         [Test]
+        public void Test_ParentSpanId()
+        {
+            var resultNRSpan0 = resultNRSpansDic[_otSpans[0].Context.SpanId.ToHexString()];
+            var resultNRSpan1 = resultNRSpansDic[_otSpans[1].Context.SpanId.ToHexString()];
+            var resultNRSpan2 = resultNRSpansDic[_otSpans[2].Context.SpanId.ToHexString()];
+
+            Assert.IsNull(resultNRSpan0.ParentId, "Top Level Span should have NULL parentID");
+            Assert.AreEqual(resultNRSpan1.ParentId, resultNRSpan0.Id, "Mismatch on ParentId - Span1 is a child of Span0");
+            Assert.IsNull(resultNRSpan2.ParentId, "Top Level Span should have NULL parentID");
+        }
+
+        [Test]
         public void Test_FilterOutNewRelicEndpoint()
         {
             Assert.IsFalse(resultNRSpansDic.ContainsKey(_otSpans[3].Context.SpanId.ToHexString()), "Endpoint calls to New Relic should be excluded");

--- a/src/OpenTelemetry.Exporter.NewRelic/NewRelicTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.NewRelic/NewRelicTraceExporter.cs
@@ -21,6 +21,7 @@ namespace OpenTelemetry.Exporter.NewRelic
         private readonly NRSpans.SpanDataSender _spanDataSender;
 
         private const string _attribName_url = "http.url";
+        private const string _parentId_NullValue = "0000000000000000";
 
         private readonly ILogger _logger;
         private readonly TelemetryConfiguration _config;
@@ -146,7 +147,7 @@ namespace OpenTelemetry.Exporter.NewRelic
                 newRelicSpanBuilder.WithServiceName(_config.ServiceName);
             }
 
-            if (openTelemetrySpan.ParentSpanId != null)
+            if (openTelemetrySpan.ParentSpanId != null && openTelemetrySpan.ParentSpanId.ToHexString() != _parentId_NullValue)
             {
                 newRelicSpanBuilder.WithParentId(openTelemetrySpan.ParentSpanId.ToHexString());
             }


### PR DESCRIPTION
* Exposes getter function for ParentID on TelemetrySDK Span Object.
* Internally Exposes const for prop names on SpanConverter.
* Adds logic to SpanConverter to not set ParentID if it is NULL or Empty (000000) value.
* Adds test for Parent Id