### PR TITLE
remove local icon file reference in .csproj

### DIFF
--- a/src/NewRelic.Telemetry/NewRelic.Telemetry.csproj
+++ b/src/NewRelic.Telemetry/NewRelic.Telemetry.csproj
@@ -10,7 +10,6 @@
 
     <PackageId>NewRelic.Telemetry</PackageId>
     <PackageTags>newrelic</PackageTags>
-    <PackageIcon>avatar-newrelic.png</PackageIcon>
     <PackageProjectUrl>https://github.com/newrelic/newrelic-telemetry-sdk-dotnet</PackageProjectUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
remove this .csproj reference to the icon file. icon will be obtained from PackageIconUrl. This was mistakenly updated automatically.