### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Support for sending spans to the New Relic
+- 
 
-## [1.0.0] - 2019-??-??
+## [1.0.0-beta] - 2019-12-11
 ### Added
-- TBD
+- Initial beta release of the New Relic Telemetry SDK and OpenTelemetry Exporter for .NET. Supports sending spans to the New Relic endpoint for visualization in the New Relic UI.
 
 [Unreleased]: https://github.com/newrelic/newrelic-telemetry-sdk-dotnet/compare/9793b2c..HEAD


### PR DESCRIPTION
For initial beta release - 1.0.0-beta - of the Telemetry SDK and OpenTelemetry Exporter.