### PR TITLE
DOTNET-4483 - Rename Identifiers

### DIFF
--- a/src/NewRelic.Telemetry.Samples/ConsoleApplicationWithTracer/SimpleTracer.cs
+++ b/src/NewRelic.Telemetry.Samples/ConsoleApplicationWithTracer/SimpleTracer.cs
@@ -47,7 +47,7 @@ namespace ConsoleApplicationWithTracer
         /// <param name="apiKey">Required: API Key to communicate with New Relic endpoint</param>
         public static void WithDefaultConfiguration(string apiKey)
         {
-            _currentConfig = new TelemetryConfiguration().WithAPIKey(apiKey);
+            _currentConfig = new TelemetryConfiguration().WithApiKey(apiKey);
         }
 
         /// <summary>

--- a/src/NewRelic.Telemetry.Tests/DataSenderTests.cs
+++ b/src/NewRelic.Telemetry.Tests/DataSenderTests.cs
@@ -26,7 +26,7 @@ namespace NewRelic.Telemetry.Tests
                 .WithSpan(SpanBuilder.Create("TestSpan").Build())
                 .Build();
 
-            var config = new TelemetryConfiguration().WithAPIKey("12345");
+            var config = new TelemetryConfiguration().WithApiKey("12345");
 
             var dataSender = new SpanDataSender(config);
 
@@ -68,7 +68,7 @@ namespace NewRelic.Telemetry.Tests
                 .WithSpan(SpanBuilder.Create("TestSpan").Build())
                 .Build();
 
-            var config = new TelemetryConfiguration().WithAPIKey("12345");
+            var config = new TelemetryConfiguration().WithApiKey("12345");
 
             var dataSender = new SpanDataSender(config);
 
@@ -133,7 +133,7 @@ namespace NewRelic.Telemetry.Tests
             // Arrange
             var successfulSpanBatches = new List<SpanBatch>();
 
-            var dataSender = new SpanDataSender(new TelemetryConfiguration().WithAPIKey("123456"));
+            var dataSender = new SpanDataSender(new TelemetryConfiguration().WithApiKey("123456"));
 
             var okJsons = new List<string>();
 
@@ -224,7 +224,7 @@ namespace NewRelic.Telemetry.Tests
             var actualCountCallsSendData = 0;
             var successfulSpans = new List<Span>();
 
-            var dataSender = new SpanDataSender(new TelemetryConfiguration().WithAPIKey("123456"));
+            var dataSender = new SpanDataSender(new TelemetryConfiguration().WithApiKey("123456"));
 
             var shouldSplitJsons = new List<string>();
 
@@ -290,7 +290,7 @@ namespace NewRelic.Telemetry.Tests
             var actualBackoffSequenceFromTestRun = new List<int>();
             var actualCountCallsSendData = 0;
 
-            var dataSender = new SpanDataSender(new TelemetryConfiguration().WithAPIKey("123456"));
+            var dataSender = new SpanDataSender(new TelemetryConfiguration().WithApiKey("123456"));
             dataSender.WithDelayFunction(async (int milliSecondsDelay) =>
             {
                 actualBackoffSequenceFromTestRun.Add(milliSecondsDelay);
@@ -333,7 +333,7 @@ namespace NewRelic.Telemetry.Tests
 
             var actualBackoffSequenceFromTestRun = new List<int>();
 
-            var dataSender = new SpanDataSender(new TelemetryConfiguration().WithAPIKey("123456"));
+            var dataSender = new SpanDataSender(new TelemetryConfiguration().WithApiKey("123456"));
             dataSender.WithDelayFunction(async (int milliSecondsDelay) =>
             {
                 actualBackoffSequenceFromTestRun.Add(milliSecondsDelay);
@@ -389,7 +389,7 @@ namespace NewRelic.Telemetry.Tests
 
             var actualBackoffSequenceFromTestRun = new List<int>();
 
-            var dataSender = new SpanDataSender(new TelemetryConfiguration().WithAPIKey("123456"));
+            var dataSender = new SpanDataSender(new TelemetryConfiguration().WithApiKey("123456"));
             dataSender.WithDelayFunction(async (int milliSecondsDelay) =>
             {
                 actualBackoffSequenceFromTestRun.Add(milliSecondsDelay);
@@ -434,7 +434,7 @@ namespace NewRelic.Telemetry.Tests
 
             var actualBackoffSequenceFromTestRun = new List<int>();
 
-            var dataSender = new SpanDataSender(new TelemetryConfiguration().WithAPIKey("123456"));
+            var dataSender = new SpanDataSender(new TelemetryConfiguration().WithApiKey("123456"));
 
             dataSender.WithDelayFunction(async (int milliSecondsDelay) =>
             {
@@ -478,7 +478,7 @@ namespace NewRelic.Telemetry.Tests
         {
             const int expectedNumSendBatchAsyncCall = 1;
 
-            var dataSender = new SpanDataSender(new TelemetryConfiguration().WithAPIKey("123456"));
+            var dataSender = new SpanDataSender(new TelemetryConfiguration().WithApiKey("123456"));
 
             dataSender.WithDelayFunction(async (int milliSecondsDelay) =>
             {
@@ -516,7 +516,7 @@ namespace NewRelic.Telemetry.Tests
             const int expectedNumSendBatchAsyncCall = 1;
             const int expectedNumHttpHandlerCall = 0;
 
-            var dataSender = new SpanDataSender(new TelemetryConfiguration().WithAPIKey("123456"));
+            var dataSender = new SpanDataSender(new TelemetryConfiguration().WithApiKey("123456"));
 
             dataSender.WithDelayFunction(async (int milliSecondsDelay) =>
             {
@@ -562,7 +562,7 @@ namespace NewRelic.Telemetry.Tests
         [TestCase("productName", "1.0.0")]
         public void AddVersionInfo(string productName, string productVersion)
         {
-            var dataSender = new SpanDataSender(new TelemetryConfiguration().WithAPIKey("123456"));
+            var dataSender = new SpanDataSender(new TelemetryConfiguration().WithApiKey("123456"));
             var fieldInfo = dataSender.GetType().GetField("_userAgent", BindingFlags.NonPublic | BindingFlags.Instance);
             var userAgentValueBefore = fieldInfo.GetValue(dataSender);
 

--- a/src/NewRelic.Telemetry.Tests/SpanDataSenderTests.cs
+++ b/src/NewRelic.Telemetry.Tests/SpanDataSenderTests.cs
@@ -16,7 +16,7 @@ namespace NewRelic.Telemetry.Tests
                 .WithTraceId(traceId)
                 .Build();
 
-            var dataSender = new SpanDataSender(new TelemetryConfiguration().WithAPIKey("123456"));
+            var dataSender = new SpanDataSender(new TelemetryConfiguration().WithApiKey("123456"));
 
             dataSender.WithHttpHandlerImpl((serializedJson) =>
             {
@@ -39,7 +39,7 @@ namespace NewRelic.Telemetry.Tests
                 .WithSpan(SpanBuilder.Create("TestSpan").Build())
                 .Build();
 
-            var dataSender = new SpanDataSender(new TelemetryConfiguration().WithAPIKey("123456"));
+            var dataSender = new SpanDataSender(new TelemetryConfiguration().WithApiKey("123456"));
 
             dataSender.WithHttpHandlerImpl((serializedJson) =>
             {

--- a/src/NewRelic.Telemetry/Spans/README.md
+++ b/src/NewRelic.Telemetry/Spans/README.md
@@ -120,7 +120,7 @@ public class WeatherForecastController : ApiController
 
         // Create a new Telemetry Configuration Object with the API Key retrieved
         // from the Web.Config
-        var telemetryConfig = new TelemetryConfiguration().WithAPIKey(apiKey);
+        var telemetryConfig = new TelemetryConfiguration().WithApiKey(apiKey);
 
         // Instantiate the SpanDataSender which manages the communication with New
         // Relic endpoints

--- a/src/NewRelic.Telemetry/TelemetryConfiguration.cs
+++ b/src/NewRelic.Telemetry/TelemetryConfiguration.cs
@@ -152,7 +152,7 @@ namespace NewRelic.Telemetry
         /// have been instructed to do so by New Relic Technical Support.
         /// </summary>
         /// <param name="url"></param>
-        public TelemetryConfiguration WithOverrideEndpointUrl_Trace(string url)
+        public TelemetryConfiguration WithOverrideEndpointUrlTrace(string url)
         {
             TraceUrl = url;
             return this;
@@ -164,7 +164,7 @@ namespace NewRelic.Telemetry
         /// </summary>
         /// <param name="apiKey"></param>
         /// <see cref="https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/introduction-event-api#register">for more information</see>
-        public TelemetryConfiguration WithAPIKey(string apiKey)
+        public TelemetryConfiguration WithApiKey(string apiKey)
         {
             ApiKey = apiKey;
             return this;

--- a/src/OpenTelemetry.Exporter.NewRelic.Tests/SpanConverterTests.cs
+++ b/src/OpenTelemetry.Exporter.NewRelic.Tests/SpanConverterTests.cs
@@ -24,7 +24,7 @@ namespace OpenTelemetry.Exporter.NewRelic.Tests
         [SetUp]
 		public void Setup()
 		{
-            var config = new TelemetryConfiguration().WithAPIKey("123456").WithServiceName(testServiceName);
+            var config = new TelemetryConfiguration().WithApiKey("123456").WithServiceName(testServiceName);
             var mockDataSender = new NRSpans.SpanDataSender(config);
 
             //Capture the spans that were requested to be sent to New Relic.

--- a/src/OpenTelemetry.Exporter.NewRelic/NewRelicOpenTelemetryExtensions.cs
+++ b/src/OpenTelemetry.Exporter.NewRelic/NewRelicOpenTelemetryExtensions.cs
@@ -82,7 +82,7 @@ namespace OpenTelemetry.Exporter.NewRelic
         /// <returns></returns>
         public static TracerBuilder UseNewRelic(this TracerBuilder builder, string apiKey, ILoggerFactory loggerFactory)
         {
-            return UseNewRelic(builder, new TelemetryConfiguration().WithAPIKey(apiKey), loggerFactory);
+            return UseNewRelic(builder, new TelemetryConfiguration().WithApiKey(apiKey), loggerFactory);
         }
     }
 }


### PR DESCRIPTION
* Renamed `APIKey`->`ApiKey`
* Renamed `OverrideEndpointUrl_Trace` -> `OverrideEndpointUrlTrace`
