### PR TITLE
Dotnet 4468 add back fx sample apps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,9 +8,15 @@ variables:
   buildConfiguration: 'Release'
 
 steps:
-- script: msbuild /p:Configuration=$(buildConfiguration) src/NewRelic.Telemetry.sln 
-  
-# Build with MSBuild
+- task: NuGetToolInstaller@0
+  inputs:
+    versionSpec: '>=4.3.0' 
+ 
+- task: NuGetCommand@2
+  inputs:
+    command: 'restore'
+    restoreSolution: 'src/NewRelic.Telemetry.sln' 
+
 - task: MSBuild@1
   displayName: 'Build (configuration=$(buildConfiguration))'
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ variables:
   buildConfiguration: 'Release'
 
 steps:
-- script: dotnet build src/NewRelic.Telemetry.sln --configuration $(buildConfiguration)
+- script: msbuild /p:Configuration=$(buildConfiguration) src/NewRelic.Telemetry.sln 
   displayName: 'Build (configuration=$(buildConfiguration))'
 
 - script: dotnet test src/NewRelic.Telemetry.Tests --no-build --no-restore --configuration $(buildConfiguration) --logger trx

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,13 @@ variables:
 
 steps:
 - script: msbuild /p:Configuration=$(buildConfiguration) src/NewRelic.Telemetry.sln 
+  
+# Build with MSBuild
+- task: MSBuild@1
   displayName: 'Build (configuration=$(buildConfiguration))'
+  inputs:
+    solution: 'src/NewRelic.Telemetry.sln'
+    configuration: $(buildConfiguration) 
 
 - script: dotnet test src/NewRelic.Telemetry.Tests --no-build --no-restore --configuration $(buildConfiguration) --logger trx
   displayName: 'Run tests - TelemetrySDK'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ steps:
 - task: NuGetToolInstaller@0
   inputs:
     versionSpec: '>=4.3.0' 
- 
+
 - task: NuGetCommand@2
   inputs:
     command: 'restore'

--- a/src/NewRelic.Telemetry.Samples/ASPNetFrameworkApiApplication/ASPNetFrameworkApiApplication.csproj
+++ b/src/NewRelic.Telemetry.Samples/ASPNetFrameworkApiApplication/ASPNetFrameworkApiApplication.csproj
@@ -1,0 +1,217 @@
+﻿<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{2002CE3F-509D-4992-88AF-A4D5B306E16F}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ASPNetFrameworkApiApplication</RootNamespace>
+    <AssemblyName>ASPNetFrameworkApiApplication</AssemblyName>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <UseIISExpress>true</UseIISExpress>
+    <Use64BitIISExpress />
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Extensions.Configuration, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Configuration.3.1.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Configuration.Abstractions.3.1.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Configuration.Binder.3.1.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.3.1.0\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.3.1.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.3.1.0\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.3.1.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Options, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Options.3.1.0\lib\netstandard2.0\Microsoft.Extensions.Options.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Primitives.3.1.0\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.2.9.0\lib\net46\Serilog.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Extensions.Logging, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.Extensions.Logging.3.0.1\lib\netstandard2.0\Serilog.Extensions.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Settings.AppSettings, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.Settings.AppSettings.2.2.2\lib\net45\Serilog.Settings.AppSettings.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Console, Version=3.1.1.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.Sinks.Console.3.1.1\lib\net45\Serilog.Sinks.Console.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.Sinks.File.4.1.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Buffers.4.4.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.Annotations, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ComponentModel.Annotations.4.7.0\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Memory.4.5.2\lib\netstandard2.0\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.7.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.2\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.EnterpriseServices" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Formatting">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.7\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.WebHost">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.7\lib\net45\System.Web.Http.WebHost.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform">
+      <HintPath>..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Global.asax" />
+    <Content Include="Web.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="App_Start\WebApiConfig.cs" />
+    <Compile Include="Controllers\WeatherForecastController.cs" />
+    <Compile Include="Global.asax.cs">
+      <DependentUpon>Global.asax</DependentUpon>
+    </Compile>
+    <Compile Include="Models\WeatherForecast.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="Web.Debug.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+    <None Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="App_Data\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\NewRelic.Telemetry\NewRelic.Telemetry.csproj">
+      <Project>{62ce6d9b-449b-4956-94fc-0fbba235145f}</Project>
+      <Name>NewRelic.Telemetry</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>63126</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:63126/</IISUrl>
+          <OverrideIISAppRootUrl>True</OverrideIISAppRootUrl>
+          <IISAppRootUrl>http://localhost:63126/api/weatherforecast/get</IISAppRootUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/NewRelic.Telemetry.Samples/ASPNetFrameworkApiApplication/App_Start/WebApiConfig.cs
+++ b/src/NewRelic.Telemetry.Samples/ASPNetFrameworkApiApplication/App_Start/WebApiConfig.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http;
+
+namespace ASPNetFrameworkApiApplication
+{
+    public static class WebApiConfig
+    {
+        public static void Register(HttpConfiguration config)
+        {
+            // Web API configuration and services
+
+            // Web API routes
+            config.MapHttpAttributeRoutes();
+
+            config.Routes.MapHttpRoute(
+                name: "DefaultApi",
+                routeTemplate: "api/{controller}/{id}",
+                defaults: new { id = RouteParameter.Optional }
+            );
+        }
+    }
+}

--- a/src/NewRelic.Telemetry.Samples/ASPNetFrameworkApiApplication/Controllers/WeatherForecastController.cs
+++ b/src/NewRelic.Telemetry.Samples/ASPNetFrameworkApiApplication/Controllers/WeatherForecastController.cs
@@ -1,0 +1,125 @@
+﻿using Serilog;
+using System.Configuration;
+using System.Web.Http;
+using Microsoft.Extensions.Logging;
+using NewRelic.Telemetry;
+using NewRelic.Telemetry.Spans;
+using System;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using ASPNetFrameworkApiApplication.Models;
+using System.Linq;
+using NewRelic.Telemetry.Transport;
+
+namespace ASPNetFrameworkApiApplication.Controllers
+{
+
+    [Route("[controller]")]
+    public class WeatherForecastController : ApiController
+    {
+
+        private readonly Microsoft.Extensions.Logging.ILogger _logger;
+
+        // Handle to the Data Sender which manages the communication with the New Relic endpoint
+        private readonly SpanDataSender _spanDataSender;
+
+        public WeatherForecastController()
+        {
+            // Obtain the API from the Web.Config file
+            var apiKey = ConfigurationManager.AppSettings["NewRelic.Telemetry.ApiKey"];
+
+            // Create a Logger Factory using settings in the Web.Config File
+            var loggerConfig = new LoggerConfiguration()
+                .ReadFrom.AppSettings();
+            
+            var loggerFactory = new LoggerFactory()
+                .AddSerilog(loggerConfig.CreateLogger());
+
+            _logger = loggerFactory.CreateLogger<WeatherForecastController>();
+            
+            // Create a new Telemetry Configuration Object with the API Key retrieved
+            // from the Web.Config
+            var telemetryConfig = new TelemetryConfiguration().WithAPIKey(apiKey);
+
+            // Instantiate the SpanDataSender which manages the communication with New
+            // Relic endpoints
+            _spanDataSender = new SpanDataSender(telemetryConfig, loggerFactory);
+        }
+
+        private static readonly string[] Summaries = new[]
+        {
+            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+        };
+
+        [HttpGet]
+        [Route("api/WeatherForecast/Get")]
+        public async Task<IEnumerable<WeatherForecast>> Get()
+        {
+
+            // The SpanBuilder is a tool to help Build spans.  Each span must have 
+            // a unique identifier.  In this example, we are using a Guid.
+            var spanId = Guid.NewGuid().ToString();
+
+            var spanBuilder = SpanBuilder.Create(spanId);
+
+            // We can add additional attribution to a span using helper functions.
+            // In this case a timestamp and the controller action name are recorded
+            spanBuilder.WithTimestamp(DateTimeOffset.UtcNow)
+                .WithName("WeatherForecast/Get");
+
+            // Wrapping the unit of work inside a try/catch is helpful to ensure that
+            // spans are always reported to the endpoint, even if they have exceptions.
+            try
+            {
+                // This is the unit of work being tracked by the span.
+                var rng = new Random();
+                var result = Enumerable.Range(1, 5)
+                    .Select(index => new WeatherForecast()
+                    {
+                        Date = DateTime.Now.AddDays(index),
+                        TemperatureC = rng.Next(-20, 55),
+                        Summary = Summaries[rng.Next(Summaries.Length)]
+                    })
+                    .ToArray();
+
+                return result;
+            }
+            // If an unhandled exception occurs, it can be denoted on the span.
+            catch (Exception ex)
+            {
+                // In the event of an exception
+                spanBuilder.HasError(true);
+                spanBuilder.WithAttribute("Exception", ex);
+
+                //This ensures that tracking of spans doesn't interfere with the normal execution flow
+                throw;
+            }
+            // In all cases, the span is sent up to the New Relic endpoint.
+            finally
+            {
+                // Obtain the span from the SpanBuilder.
+                var span = spanBuilder.Build();
+
+                // The SpanBatchBuilder is a tool to help create SpanBatches
+                // Create a new SpanBatchBuilder and associate the span to it.
+                var spanBatchBuilder = SpanBatchBuilder.Create()
+                    .WithSpan(span);
+
+                // Since this SpanBatch represents a single trace, identify
+                // the TraceId for the entire batch.
+                spanBatchBuilder.WithTraceId(Guid.NewGuid().ToString());
+
+                // Obtain the spanBatch from the builder
+                var spanBatch = spanBatchBuilder.Build();
+
+                // Send it to the New Relic endpoint.
+                var newRelicResult = await _spanDataSender.SendDataAsync(spanBatch);
+
+                if (newRelicResult.ResponseStatus == NewRelicResponseStatus.Failure)
+                {
+                    _logger.LogWarning("There was a problem sending the SpanBatch to New Relic endpoint");
+                }
+            }
+        }
+    }
+}

--- a/src/NewRelic.Telemetry.Samples/ASPNetFrameworkApiApplication/Global.asax
+++ b/src/NewRelic.Telemetry.Samples/ASPNetFrameworkApiApplication/Global.asax
@@ -1,0 +1,1 @@
+﻿<%@ Application Codebehind="Global.asax.cs" Inherits="ASPNetFrameworkApiApplication.WebApiApplication" Language="C#" %>

--- a/src/NewRelic.Telemetry.Samples/ASPNetFrameworkApiApplication/Global.asax.cs
+++ b/src/NewRelic.Telemetry.Samples/ASPNetFrameworkApiApplication/Global.asax.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Http;
+using System.Web.Routing;
+
+namespace ASPNetFrameworkApiApplication
+{
+    public class WebApiApplication : System.Web.HttpApplication
+    {
+        protected void Application_Start()
+        {
+            GlobalConfiguration.Configure(WebApiConfig.Register);
+        }
+    }
+}

--- a/src/NewRelic.Telemetry.Samples/ASPNetFrameworkApiApplication/Models/WeatherForecast.cs
+++ b/src/NewRelic.Telemetry.Samples/ASPNetFrameworkApiApplication/Models/WeatherForecast.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace ASPNetFrameworkApiApplication.Models
+{
+	public class WeatherForecast
+	{
+		public DateTime Date { get; set; }
+
+		public int TemperatureC { get; set; }
+
+		public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+		public string Summary { get; set; }
+	}
+}

--- a/src/NewRelic.Telemetry.Samples/ASPNetFrameworkApiApplication/Properties/AssemblyInfo.cs
+++ b/src/NewRelic.Telemetry.Samples/ASPNetFrameworkApiApplication/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ASPNetFrameworkApiApplication")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ASPNetFrameworkApiApplication")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("2002ce3f-509d-4992-88af-a4d5b306e16f")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NewRelic.Telemetry.Samples/ASPNetFrameworkApiApplication/Web.config
+++ b/src/NewRelic.Telemetry.Samples/ASPNetFrameworkApiApplication/Web.config
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  For more information on how to configure your ASP.NET application, please visit
+  https://go.microsoft.com/fwlink/?LinkId=301879
+  -->
+<configuration>
+  <appSettings>
+    <add key="NewRelic.Telemetry.ApiKey" value="YOUR-API_KEY" />
+    <add key="serilog:using:File" value="Serilog.Sinks.File" />
+    <add key="serilog:write-to:File.path" value="C:\logs\SerilogExample.log.json" />
+  </appSettings>
+  <system.web>
+    <compilation debug="true" targetFramework="4.7" />
+    <httpRuntime targetFramework="4.7" />
+  </system.web>
+  <system.webServer>
+    <handlers>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+    </handlers>
+  </system.webServer>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <system.codedom>
+    <compilers>
+      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
+    </compilers>
+  </system.codedom>
+</configuration>

--- a/src/NewRelic.Telemetry.Samples/ASPNetFrameworkApiApplication/packages.config
+++ b/src/NewRelic.Telemetry.Samples/ASPNetFrameworkApiApplication/packages.config
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.WebApi" version="5.2.7" targetFramework="net47" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net47" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.7" targetFramework="net47" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.7" targetFramework="net47" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net47" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.Configuration" version="3.1.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="3.1.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="3.1.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="3.1.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="3.1.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.Logging" version="3.1.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="3.1.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.Options" version="3.1.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.Primitives" version="3.1.0" targetFramework="net47" />
+  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net47" />
+  <package id="Serilog" version="2.9.0" targetFramework="net47" />
+  <package id="Serilog.Extensions.Logging" version="3.0.1" targetFramework="net47" />
+  <package id="Serilog.Settings.AppSettings" version="2.2.2" targetFramework="net47" />
+  <package id="Serilog.Sinks.Console" version="3.1.1" targetFramework="net47" />
+  <package id="Serilog.Sinks.File" version="4.1.0" targetFramework="net47" />
+  <package id="System.Buffers" version="4.4.0" targetFramework="net47" />
+  <package id="System.ComponentModel.Annotations" version="4.7.0" targetFramework="net47" />
+  <package id="System.Memory" version="4.5.2" targetFramework="net47" />
+  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net47" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.0" targetFramework="net47" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.2" targetFramework="net47" />
+</packages>

--- a/src/NewRelic.Telemetry.sln
+++ b/src/NewRelic.Telemetry.sln
@@ -41,6 +41,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BasicConsoleApplication", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCoreWebApiApplication", "NewRelic.Telemetry.Samples\AspNetCoreWebApiApplication\AspNetCoreWebApiApplication.csproj", "{408E065C-BEA1-461C-B2D4-7879261C8EBE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleAspNetFrameworkApp", "OpenTelemetry.Exporter.NewRelic.Samples\SampleAspNetFrameworkApp\SampleAspNetFrameworkApp.csproj", "{59A82C1E-3349-466B-8FD6-5EBC93B1141A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ASPNetFrameworkApiApplication", "NewRelic.Telemetry.Samples\ASPNetFrameworkApiApplication\ASPNetFrameworkApiApplication.csproj", "{2002CE3F-509D-4992-88AF-A4D5B306E16F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -147,6 +151,30 @@ Global
 		{408E065C-BEA1-461C-B2D4-7879261C8EBE}.Release|x64.Build.0 = Release|Any CPU
 		{408E065C-BEA1-461C-B2D4-7879261C8EBE}.Release|x86.ActiveCfg = Release|Any CPU
 		{408E065C-BEA1-461C-B2D4-7879261C8EBE}.Release|x86.Build.0 = Release|Any CPU
+		{59A82C1E-3349-466B-8FD6-5EBC93B1141A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{59A82C1E-3349-466B-8FD6-5EBC93B1141A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{59A82C1E-3349-466B-8FD6-5EBC93B1141A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{59A82C1E-3349-466B-8FD6-5EBC93B1141A}.Debug|x64.Build.0 = Debug|Any CPU
+		{59A82C1E-3349-466B-8FD6-5EBC93B1141A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{59A82C1E-3349-466B-8FD6-5EBC93B1141A}.Debug|x86.Build.0 = Debug|Any CPU
+		{59A82C1E-3349-466B-8FD6-5EBC93B1141A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{59A82C1E-3349-466B-8FD6-5EBC93B1141A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{59A82C1E-3349-466B-8FD6-5EBC93B1141A}.Release|x64.ActiveCfg = Release|Any CPU
+		{59A82C1E-3349-466B-8FD6-5EBC93B1141A}.Release|x64.Build.0 = Release|Any CPU
+		{59A82C1E-3349-466B-8FD6-5EBC93B1141A}.Release|x86.ActiveCfg = Release|Any CPU
+		{59A82C1E-3349-466B-8FD6-5EBC93B1141A}.Release|x86.Build.0 = Release|Any CPU
+		{2002CE3F-509D-4992-88AF-A4D5B306E16F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2002CE3F-509D-4992-88AF-A4D5B306E16F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2002CE3F-509D-4992-88AF-A4D5B306E16F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2002CE3F-509D-4992-88AF-A4D5B306E16F}.Debug|x64.Build.0 = Debug|Any CPU
+		{2002CE3F-509D-4992-88AF-A4D5B306E16F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2002CE3F-509D-4992-88AF-A4D5B306E16F}.Debug|x86.Build.0 = Debug|Any CPU
+		{2002CE3F-509D-4992-88AF-A4D5B306E16F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2002CE3F-509D-4992-88AF-A4D5B306E16F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2002CE3F-509D-4992-88AF-A4D5B306E16F}.Release|x64.ActiveCfg = Release|Any CPU
+		{2002CE3F-509D-4992-88AF-A4D5B306E16F}.Release|x64.Build.0 = Release|Any CPU
+		{2002CE3F-509D-4992-88AF-A4D5B306E16F}.Release|x86.ActiveCfg = Release|Any CPU
+		{2002CE3F-509D-4992-88AF-A4D5B306E16F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -162,6 +190,8 @@ Global
 		{647540D5-0080-4594-879E-8F3394F3E391} = {F028FF9D-9262-45A6-AC4D-79C54943DB03}
 		{131E8A7A-2FC0-4D1F-84E6-0A3CCE37DE1D} = {F028FF9D-9262-45A6-AC4D-79C54943DB03}
 		{408E065C-BEA1-461C-B2D4-7879261C8EBE} = {F028FF9D-9262-45A6-AC4D-79C54943DB03}
+		{59A82C1E-3349-466B-8FD6-5EBC93B1141A} = {FECC3BEB-820C-4B94-BB0E-98228ADE6237}
+		{2002CE3F-509D-4992-88AF-A4D5B306E16F} = {F028FF9D-9262-45A6-AC4D-79C54943DB03}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {08D1630D-EA85-4E78-ABBA-34195DCA7595}

--- a/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/App_Start/WebApiConfig.cs
+++ b/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/App_Start/WebApiConfig.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http;
+
+namespace SampleAspNetFrameworkApp
+{
+    public static class WebApiConfig
+    {
+        public static void Register(HttpConfiguration config)
+        {
+            // Web API configuration and services
+
+            // Web API routes
+            config.MapHttpAttributeRoutes();
+
+            config.Routes.MapHttpRoute(
+                name: "DefaultApi",
+                routeTemplate: "api/{controller}/{id}",
+                defaults: new { id = RouteParameter.Optional }
+            );
+            
+        }
+    }
+}

--- a/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/Controllers/WeatherForecastController.cs
+++ b/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/Controllers/WeatherForecastController.cs
@@ -1,0 +1,53 @@
+﻿using ASPNetFrameworkApiApplication.Models;
+using OpenTelemetry.Trace;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Web.Http;
+
+namespace SampleAspNetFrameworkApp.Controllers
+{
+    public class WeatherForecastController : ApiController
+    { 
+        private static readonly string[] Summaries = new[]
+        {
+            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+        };
+
+        [HttpGet]
+        public async Task<IEnumerable<WeatherForecast>> Get()
+        {
+            var span = WebApiApplication.OTTracer.StartRootSpan("/WeatherForecastController/Get");
+
+            // Wrapping the unit of work inside a try/catch is helpful to ensure that
+            // spans are always reported to the endpoint, even if they have exceptions.
+            try
+            {
+                // This is the unit of work being tracked by the span.
+                var rng = new Random();
+                var result = Enumerable.Range(1, 5)
+                    .Select(index => new WeatherForecast()
+                    {
+                        Date = DateTime.Now.AddDays(index),
+                        TemperatureC = rng.Next(-20, 55),
+                        Summary = Summaries[rng.Next(Summaries.Length)]
+                    })
+                    .ToArray();
+
+                return result;
+            }
+            // If an unhandled exception occurs, it can be denoted on the span.
+            catch (Exception ex)
+            {
+                span.Status = Status.Internal;
+                throw;
+            }
+            // In all cases, the span is sent up to the New Relic endpoint.
+            finally
+            {
+                span.End();
+            }
+        }
+    }
+}

--- a/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/Global.asax
+++ b/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/Global.asax
@@ -1,0 +1,1 @@
+﻿<%@ Application Codebehind="Global.asax.cs" Inherits="SampleAspNetFrameworkApp.WebApiApplication" Language="C#" %>

--- a/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/Global.asax.cs
+++ b/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/Global.asax.cs
@@ -1,0 +1,37 @@
+using System.Configuration;
+using System.Web.Http;
+using OpenTelemetry.Collector.Dependencies;
+using OpenTelemetry.Trace.Configuration;
+using OpenTelemetry.Exporter.NewRelic;
+using OpenTelemetry.Trace.Sampler;
+using OpenTelemetry.Trace;
+
+namespace SampleAspNetFrameworkApp
+{
+    public class WebApiApplication : System.Web.HttpApplication
+    {
+        // Static handle to the OpenTelemetry Tracer
+        public static ITracer OTTracer;
+
+        protected void Application_Start()
+        {
+            GlobalConfiguration.Configure(WebApiConfig.Register);
+
+            // Obtain the API Key from the Web.Config file
+            var apiKey = ConfigurationManager.AppSettings["NewRelic.Telemetry.ApiKey"];
+
+            // Create the tracer factory registering New Relic as the Data Exporter
+            var tracerFactory = TracerFactory.Create((b) =>
+            {
+                b.UseNewRelic(apiKey)
+                .AddDependencyCollector()
+                .SetSampler(Samplers.AlwaysSample);
+            });
+
+            var dependenciesCollector = new DependenciesCollector(new HttpClientCollectorOptions(), tracerFactory);
+
+            // Make the tracer available to the application
+            OTTracer = tracerFactory.GetTracer("SampleAspNetFrameworkApp");
+        }
+    }
+}

--- a/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/Models/WeatherForecast.cs
+++ b/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/Models/WeatherForecast.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace ASPNetFrameworkApiApplication.Models
+{
+	public class WeatherForecast
+	{
+		public DateTime Date { get; set; }
+
+		public int TemperatureC { get; set; }
+
+		public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+		public string Summary { get; set; }
+	}
+}

--- a/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/Properties/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SampleAspNetFrameworkApp")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SampleAspNetFrameworkApp")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("59a82c1e-3349-466b-8fd6-5ebc93b1141a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/SampleAspNetFrameworkApp.csproj
+++ b/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/SampleAspNetFrameworkApp.csproj
@@ -1,0 +1,228 @@
+﻿<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{59A82C1E-3349-466B-8FD6-5EBC93B1141A}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SampleAspNetFrameworkApp</RootNamespace>
+    <AssemblyName>SampleAspNetFrameworkApp</AssemblyName>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <UseIISExpress>true</UseIISExpress>
+    <Use64BitIISExpress />
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Extensions.Configuration, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Configuration.2.1.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Configuration.Abstractions.2.1.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Configuration.Binder.2.1.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.2.1.0\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.FileProviders.Abstractions.2.1.0\lib\netstandard2.0\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.FileProviders.Physical, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.FileProviders.Physical.2.1.0\lib\netstandard2.0\Microsoft.Extensions.FileProviders.Physical.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.FileSystemGlobbing, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.FileSystemGlobbing.2.1.0\lib\netstandard2.0\Microsoft.Extensions.FileSystemGlobbing.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Hosting, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Hosting.2.1.0\lib\netstandard2.0\Microsoft.Extensions.Hosting.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Hosting.Abstractions.2.1.0\lib\netstandard2.0\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.2.1.0\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.2.1.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Options, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Options.2.1.0\lib\netstandard2.0\Microsoft.Extensions.Options.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Primitives.2.1.0\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="OpenTelemetry, Version=0.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\OpenTelemetry.0.2.0-alpha.100\lib\net46\OpenTelemetry.dll</HintPath>
+    </Reference>
+    <Reference Include="OpenTelemetry.Api, Version=0.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\OpenTelemetry.Api.0.2.0-alpha.100\lib\net45\OpenTelemetry.Api.dll</HintPath>
+    </Reference>
+    <Reference Include="OpenTelemetry.Collector.Dependencies, Version=0.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\OpenTelemetry.Collector.Dependencies.0.2.0-alpha.100\lib\netstandard2.0\OpenTelemetry.Collector.Dependencies.dll</HintPath>
+    </Reference>
+    <Reference Include="OpenTelemetry.Hosting, Version=0.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\OpenTelemetry.Hosting.0.2.0-alpha.100\lib\netstandard2.0\OpenTelemetry.Hosting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Buffers.4.4.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=1.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.4.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.6.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Memory.4.5.3\lib\netstandard2.0\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.EnterpriseServices" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Formatting">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.7\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.WebHost">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.7\lib\net45\System.Web.Http.WebHost.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform">
+      <HintPath>..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Global.asax" />
+    <Content Include="Web.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="App_Start\WebApiConfig.cs" />
+    <Compile Include="Controllers\WeatherForecastController.cs" />
+    <Compile Include="Global.asax.cs">
+      <DependentUpon>Global.asax</DependentUpon>
+    </Compile>
+    <Compile Include="Models\WeatherForecast.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="Web.Debug.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+    <None Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="App_Data\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\NewRelic.Telemetry\NewRelic.Telemetry.csproj">
+      <Project>{62CE6D9B-449B-4956-94FC-0FBBA235145F}</Project>
+      <Name>NewRelic.Telemetry</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\OpenTelemetry.Exporter.NewRelic\OpenTelemetry.Exporter.NewRelic.csproj">
+      <Project>{2477cd19-50d2-44e3-bc83-bcfe027b60b8}</Project>
+      <Name>OpenTelemetry.Exporter.NewRelic</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>63069</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:63069/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/Web.Debug.config
+++ b/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/Web.Debug.config
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/Web.Release.config
+++ b/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/Web.Release.config
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/Web.config
+++ b/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/Web.config
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  For more information on how to configure your ASP.NET application, please visit
+  https://go.microsoft.com/fwlink/?LinkId=301879
+  -->
+<configuration>
+  <appSettings>
+    <add key="NewRelic.Telemetry.ApiKey" value="YOUR API KEY" />
+    <add key="serilog:using:File" value="Serilog.Sinks.File" />
+    <add key="serilog:write-to:File.path" value="C:\logs\SerilogExample.log.json" />
+  </appSettings>
+  <system.web>
+    <compilation debug="true" targetFramework="4.7" />
+    <httpRuntime targetFramework="4.7" />
+  </system.web>
+  <system.webServer>
+    <handlers>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+    </handlers>
+  </system.webServer>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.4.1" newVersion="4.0.4.1" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <system.codedom>
+    <compilers>
+      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
+    </compilers>
+  </system.codedom>
+</configuration>

--- a/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/packages.config
+++ b/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/packages.config
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.WebApi" version="5.2.7" targetFramework="net47" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net47" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.7" targetFramework="net47" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.7" targetFramework="net47" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.Configuration" version="2.1.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="2.1.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="2.1.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="2.1.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="2.1.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.FileProviders.Physical" version="2.1.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.FileSystemGlobbing" version="2.1.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.Hosting" version="2.1.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.Hosting.Abstractions" version="2.1.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.Logging" version="2.1.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="2.1.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.Options" version="2.1.0" targetFramework="net47" />
+  <package id="Microsoft.Extensions.Primitives" version="2.1.0" targetFramework="net47" />
+  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net47" />
+  <package id="OpenTelemetry" version="0.2.0-alpha.100" targetFramework="net47" />
+  <package id="OpenTelemetry.Api" version="0.2.0-alpha.100" targetFramework="net47" />
+  <package id="OpenTelemetry.Collector.Dependencies" version="0.2.0-alpha.100" targetFramework="net47" />
+  <package id="OpenTelemetry.Hosting" version="0.2.0-alpha.100" targetFramework="net47" />
+  <package id="System.Buffers" version="4.4.0" targetFramework="net47" />
+  <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net47" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.6.0" targetFramework="net47" />
+  <package id="System.Memory" version="4.5.3" targetFramework="net47" />
+  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net47" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net47" />
+</packages>


### PR DESCRIPTION
Add back ASPNetFrameworkApiApplication and SampleAspNetFrameworkApp.
Fix azure-pipelines.yml to build .Net framework apps.
Test build succeeded:
![image](https://user-images.githubusercontent.com/20267975/70761598-911da280-1d02-11ea-885a-022da6eca14c.png)
