### PR TITLE
change user-agent string for exporter

### DIFF
--- a/src/OpenTelemetry.Exporter.NewRelic/NewRelicTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.NewRelic/NewRelicTraceExporter.cs
@@ -20,7 +20,7 @@ namespace OpenTelemetry.Exporter.NewRelic
     public class NewRelicTraceExporter : SpanExporter
     {
         private readonly NRSpans.SpanDataSender _spanDataSender;
-        private const string _productName = "OpenTelemetry.Exporter.NewRelic";
+        private const string _productName = "NewRelic-Dotnet-OpenTelemetry";
         private static readonly string _productVersion = Assembly.GetExecutingAssembly().GetCustomAttribute<PackageVersionAttribute>().PackageVersion;
 
         private const string _attribName_url = "http.url";


### PR DESCRIPTION
User-agent string for the exporter is [spec'd ](https://github.com/newrelic/newrelic-exporter-specs/blob/master/Common.md#user-agent-values)to be `NewRelic-Dotnet-OpenTelemetry/<version>`.

Note: This PR does not change the name of the NuGet package, however, now the NuGet package name and User-Agent in the Http header are different, whereas they were the same.