### PR TITLE
update product versions

### DIFF
--- a/src/NewRelic.Telemetry/NewRelic.Telemetry.csproj
+++ b/src/NewRelic.Telemetry/NewRelic.Telemetry.csproj
@@ -20,7 +20,7 @@
     <Build>0</Build>
     <Revision>0</Revision>
     <Version>$(Major).$(Minor).$(Build).$(Revision)</Version>
-    <PackageVersion>$(Major).$(Minor).$(Build)-beta</PackageVersion>
+    <PackageVersion>$(Major).$(Minor).$(Build)-beta001</PackageVersion>
     <AssemblyVersion>$(Major).0.0.0</AssemblyVersion>
     <FileVersion>$(Major).$(Minor).$(Build).$(Revision)</FileVersion>
 

--- a/src/OpenTelemetry.Exporter.NewRelic/OpenTelemetry.Exporter.NewRelic.csproj
+++ b/src/OpenTelemetry.Exporter.NewRelic/OpenTelemetry.Exporter.NewRelic.csproj
@@ -27,7 +27,7 @@
     <Build>0</Build>
     <Revision>0</Revision>
     <Version>$(Major).$(Minor).$(Build).$(Revision)</Version>
-    <PackageVersion>$(Major).$(Minor).$(Build)-beta</PackageVersion>
+    <PackageVersion>$(Major).$(Minor).$(Build)-beta001</PackageVersion>
     <AssemblyVersion>$(Major).0.0.0</AssemblyVersion>
     <FileVersion>$(Major).$(Minor).$(Build).$(Revision)</FileVersion>
   </PropertyGroup>


### PR DESCRIPTION
https://newrelic.atlassian.net/browse/DOTNET-4495

```Alan West 12:01 PM

the .xxx binds us to a version of the nuget tooling right
if you just drop the dot then it doesn’t require newer tooling - though then it’s important to plan for enough digits for prereleases
that is, 1.0.0-beta.9 < 1.0.0-beta.10 but 1.0.0-beta9 > 1.0.0-beta10
this tool demonstrates that: https://nugettoolsdev.azurewebsites.net/4.3.0/version-comparison
```