### PR TITLE
Instrumentation Provider and Error Messaging

### DIFF
--- a/src/NewRelic.Telemetry.Tests/SpanDataSenderTests.cs
+++ b/src/NewRelic.Telemetry.Tests/SpanDataSenderTests.cs
@@ -51,5 +51,36 @@ namespace NewRelic.Telemetry.Tests
 
             Assert.AreEqual(NewRelicResponseStatus.Success, response.ResponseStatus);
         }
+
+        [Test]
+        public void InstrumentationProviderSuppliedWhenConfigured()
+        {
+            var traceId = "123";
+            var instrumentationProvider = "TestInstrumentationProvider";
+
+            var spanBatch = SpanBatchBuilder.Create()
+                .WithTraceId(traceId)
+                .WithSpan(SpanBuilder.Create("TestSpan").Build())
+                .Build();
+
+            var dataSender = new SpanDataSender(new TelemetryConfiguration()
+                .WithApiKey("123456")
+                .WithInstrumentationProvderName(instrumentationProvider));
+
+            SpanBatch capturedSpanbatch = null;
+            dataSender.WithCaptureSendDataAsyncDelegate((spanBatch, attempt) =>
+            {
+                capturedSpanbatch = spanBatch;
+            });
+
+
+            var response = dataSender.SendDataAsync(spanBatch).Result;
+
+            Assert.IsNotNull(spanBatch);
+            Assert.AreEqual(1, spanBatch.Spans.Count);
+            Assert.IsNotNull(spanBatch.Spans[0].Attributes);
+            Assert.IsTrue(spanBatch.Spans[0].Attributes.ContainsKey("instrumentation.provider"));
+            Assert.AreEqual(instrumentationProvider,spanBatch.Spans[0].Attributes["instrumentation.provider"]);
+        }
     }
 }

--- a/src/NewRelic.Telemetry.Tests/SpanDataSenderTests.cs
+++ b/src/NewRelic.Telemetry.Tests/SpanDataSenderTests.cs
@@ -65,7 +65,7 @@ namespace NewRelic.Telemetry.Tests
 
             var dataSender = new SpanDataSender(new TelemetryConfiguration()
                 .WithApiKey("123456")
-                .WithInstrumentationProvderName(instrumentationProvider));
+                .WithInstrumentationProviderName(instrumentationProvider));
 
             SpanBatch capturedSpanbatch = null;
             dataSender.WithCaptureSendDataAsyncDelegate((spanBatch, attempt) =>

--- a/src/NewRelic.Telemetry.Tests/SpanTests.cs
+++ b/src/NewRelic.Telemetry.Tests/SpanTests.cs
@@ -37,6 +37,50 @@ namespace NewRelic.Telemetry.Tests
         }
 
         [Test]
+        public void HasErrorTest()
+        {
+            var attributes = new Dictionary<string, object>
+            { { "attrKey", "attrValue" } };
+
+            var span0 = SpanBuilder.Create("spanId")
+                .WithTraceId("traceId")
+                .WithAttributes(attributes)
+                .Build();
+
+            var span1 = SpanBuilder.Create("spanId")
+                .WithTraceId("traceId")
+                .WithAttributes(attributes)
+                .HasError(true)
+                .Build();
+
+            var span2 = SpanBuilder.Create("spanId")
+                .WithTraceId("traceId")
+                .WithAttributes(attributes)
+                .HasError("This was a bad error on span 2")
+                .Build();
+
+            var span3 = SpanBuilder.Create("spanId")
+                .WithTraceId("traceId")
+                .WithAttributes(attributes)
+                .HasError("This was a bad error on span 3")
+                .HasError(false)
+                .Build();
+
+            Assert.IsFalse(span0.Attributes.ContainsKey("error"));
+            Assert.IsFalse(span0.Attributes.ContainsKey("error.message"));
+
+            Assert.AreEqual(true, span1.Attributes["error"]);
+            Assert.IsFalse(span1.Attributes.ContainsKey("error.message"));
+
+            Assert.AreEqual(true, span2.Attributes["error"]);
+            Assert.IsTrue(span2.Attributes.ContainsKey("error.message"));
+            Assert.AreEqual("This was a bad error on span 2", span2.Attributes["error.message"]);
+
+            Assert.IsFalse(span3.Attributes.ContainsKey("error"));
+            Assert.IsFalse(span3.Attributes.ContainsKey("error.message"));
+        }
+
+        [Test]
         public void ThrowExceptionIfNullId()
         {
             Assert.Throws<NullReferenceException>(new TestDelegate(() => SpanBuilder.Create(null)));

--- a/src/NewRelic.Telemetry/Spans/SpanBuilder.cs
+++ b/src/NewRelic.Telemetry/Spans/SpanBuilder.cs
@@ -14,6 +14,8 @@ namespace NewRelic.Telemetry.Spans
         internal const string attribName_Name = "name";
         internal const string attribName_ParentID = "parent.id";
         internal const string attribName_Error = "error";
+        internal const string attribName_ErrorMsg = "error.message";
+        internal const string attribName_InstrumentationProvider = "instrumentation.provider";
 
         /// <summary>
         /// Creates a new SpanBuilder with a unique SpanId Identifier.
@@ -92,7 +94,7 @@ namespace NewRelic.Telemetry.Spans
         
         /// <summary>
         /// Used to indicate that an error has occurred during the unit of work represented
-        /// by this Span.
+        /// by this Span.  Setting hasError to false will also clear the "error.message" value.
         /// </summary>
         /// <param name="hasError"></param>
         public SpanBuilder HasError(bool hasError)
@@ -107,7 +109,29 @@ namespace NewRelic.Telemetry.Spans
                 _span.Attributes.Remove(attribName_Error);
             }
 
+            if (_span.Attributes?.ContainsKey(attribName_ErrorMsg) == true)
+            {
+                _span.Attributes.Remove(attribName_ErrorMsg);
+            }
+
             return this;
+        }
+
+        /// <summary>
+        /// Used to indicate that an error has occurred during the unit of work represented
+        /// by this Span.  Additionally records a message describing the error condition.
+        /// </summary>
+        /// <param name="hasError"></param>
+        public SpanBuilder HasError(string errorMessage)
+        {
+            HasError(true);
+
+            if (string.IsNullOrWhiteSpace(errorMessage))
+            {
+                return this;
+            }
+
+            return WithAttribute(attribName_ErrorMsg, errorMessage);
         }
 
         /// <summary>
@@ -171,7 +195,6 @@ namespace NewRelic.Telemetry.Spans
             WithAttribute(attribName_ParentID, parentId);
             return this;
         }
-
 
         /// <summary>
         /// Identifies the name of a service performing the units of work measured by these Spans.

--- a/src/NewRelic.Telemetry/Spans/SpanDataSender.cs
+++ b/src/NewRelic.Telemetry/Spans/SpanDataSender.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using NewRelic.Telemetry.Transport;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace NewRelic.Telemetry.Spans
@@ -53,6 +54,24 @@ namespace NewRelic.Telemetry.Spans
         /// <param name="loggerFactory"></param>
         public SpanDataSender(IConfiguration configProvider, ILoggerFactory loggerFactory) : base(configProvider, loggerFactory)
         {
+        }
+
+        protected override void BeforeDataSend(SpanBatch dataToSend)
+        {
+            base.BeforeDataSend(dataToSend);
+
+            if (!string.IsNullOrWhiteSpace(_config.InstrumentationProvider))
+            {
+
+                foreach (var span in dataToSend.Spans)
+                {
+                    if(span.Attributes == null)
+                    {
+                        span.Attributes = new Dictionary<string, object>();
+                    }
+                    span.Attributes[SpanBuilder.attribName_InstrumentationProvider] = _config.InstrumentationProvider;
+                }
+            }
         }
 
         protected override bool ContainsNoData(SpanBatch dataToCheck)

--- a/src/NewRelic.Telemetry/TelemetryConfiguration.cs
+++ b/src/NewRelic.Telemetry/TelemetryConfiguration.cs
@@ -236,7 +236,7 @@ namespace NewRelic.Telemetry
             return this;
         }
 
-        public TelemetryConfiguration WithInstrumentationProvderName(string providerName)
+        public TelemetryConfiguration WithInstrumentationProviderName(string providerName)
         {
             InstrumentationProvider = providerName?.Trim();
             return this;

--- a/src/NewRelic.Telemetry/TelemetryConfiguration.cs
+++ b/src/NewRelic.Telemetry/TelemetryConfiguration.cs
@@ -66,6 +66,11 @@ namespace NewRelic.Telemetry
         public string ServiceName { get; private set; }
 
         /// <summary>
+        /// Identifies the source of information that is being sent to New Relic.
+        /// </summary>
+        public string InstrumentationProvider { get; private set; }
+
+        /// <summary>
         /// A list of the New Relic endpoints where information is sent.  This collection may be used
         /// to filter out communications with New Relic endpoints during analysis.
         /// </summary>
@@ -228,6 +233,12 @@ namespace NewRelic.Telemetry
         public TelemetryConfiguration WithBackoffMaxSeconds(int backoffMaxSeconds)
         {
             BackoffMaxSeconds = backoffMaxSeconds;
+            return this;
+        }
+
+        public TelemetryConfiguration WithInstrumentationProvderName(string providerName)
+        {
+            InstrumentationProvider = providerName?.Trim();
             return this;
         }
 

--- a/src/NewRelic.Telemetry/Transport/DataSender.cs
+++ b/src/NewRelic.Telemetry/Transport/DataSender.cs
@@ -49,7 +49,6 @@ namespace NewRelic.Telemetry.Transport
 
         protected DataSender(TelemetryConfiguration config, ILoggerFactory loggerFactory)
         {
-
             _userAgentBase = "NewRelic-Dotnet-TelemetrySDK/" + _telemetrySdkVersion;
             UserAgent = _userAgentBase;
 
@@ -261,7 +260,18 @@ namespace NewRelic.Telemetry.Transport
                 return Response.Failure("API Key was not available");
             }
 
+            BeforeDataSend(dataToSend);
+
             return await SendDataAsync(dataToSend, 0);
+        }
+
+        /// <summary>
+        /// Provides a place to do any pre-work on the data to send
+        /// For example, allows updating of the instrumentation provider for spans
+        /// </summary>
+        /// <param name="dataToSend"></param>
+        protected virtual void BeforeDataSend(TData dataToSend)
+        {
         }
 
         /// <summary>

--- a/src/OpenTelemetry.Exporter.NewRelic/NewRelicTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.NewRelic/NewRelicTraceExporter.cs
@@ -72,7 +72,7 @@ namespace OpenTelemetry.Exporter.NewRelic
 
             _config = config;
 
-            _config.WithInstrumentationProvderName("opentelemetry");
+            _config.WithInstrumentationProviderName("opentelemetry");
 
             _nrEndpoints = config.NewRelicEndpoints.Select(x => x.ToLower()).ToArray();
 

--- a/src/OpenTelemetry.Exporter.NewRelic/NewRelicTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.NewRelic/NewRelicTraceExporter.cs
@@ -206,9 +206,6 @@ namespace OpenTelemetry.Exporter.NewRelic
         {
             if (openTelemetrySpan == null) throw new ArgumentNullException(nameof(openTelemetrySpan));
             if (openTelemetrySpan.Context == null) throw new NullReferenceException($"{nameof(openTelemetrySpan)}.Context");
-            if (openTelemetrySpan.Context.SpanId == null) throw new NullReferenceException($"{nameof(openTelemetrySpan)}.Context.SpanId");
-            if (openTelemetrySpan.Context.TraceId == null) throw new NullReferenceException($"{nameof(openTelemetrySpan)}.Context.TraceId");
-            if (openTelemetrySpan.StartTimestamp == null) throw new NullReferenceException($"{nameof(openTelemetrySpan)}.StartTimestamp");
 
             var newRelicSpanBuilder = NRSpans.SpanBuilder.Create(openTelemetrySpan.Context.SpanId.ToHexString())
                    .WithTraceId(openTelemetrySpan.Context.TraceId.ToHexString())
@@ -226,7 +223,7 @@ namespace OpenTelemetry.Exporter.NewRelic
                 newRelicSpanBuilder.WithServiceName(_config.ServiceName);
             }
 
-            if (openTelemetrySpan.ParentSpanId != null && openTelemetrySpan.ParentSpanId != default)
+            if (openTelemetrySpan.ParentSpanId != default)
             {
                 newRelicSpanBuilder.WithParentId(openTelemetrySpan.ParentSpanId.ToHexString());
             }


### PR DESCRIPTION
**Instrumentation Provider**
* Adds Instrumentation Provider to TelemetryConfiguration
* Telemetry SDK sets "instrumentation.provider" attribute when the instrumentation provider config setting has a value
* OpenTelemetry Provider sets the Instrumentation Provider setting to "opentelemetry"
* Open Question:   Should the base TelemetrySDK set the config value to "dotnetTelemetrySDK".

**Error**
* Adds ability for TelemetrySDK user to supply HasError with a message string.  Sets HasError = true and sets the message.
* OpenTelemetry Status.Description value will be sent if status != Status.OK as the error message
* Modified tests to set a description
