### PR TITLE
Update exporter to use OpenTelemetry 0.2.0-alpha.179

### DIFF
--- a/src/IntegrationTests/Applications/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
+++ b/src/IntegrationTests/Applications/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
@@ -3,9 +3,9 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Collector.AspNetCore" Version="0.2.0-alpha.100" />
-    <PackageReference Include="OpenTelemetry.Collector.Dependencies" Version="0.2.0-alpha.100" />
-    <PackageReference Include="OpenTelemetry.Hosting" Version="0.2.0-alpha.100" />
+    <PackageReference Include="OpenTelemetry.Collector.AspNetCore" Version="0.2.0-alpha.179" />
+    <PackageReference Include="OpenTelemetry.Collector.Dependencies" Version="0.2.0-alpha.179" />
+    <PackageReference Include="OpenTelemetry.Hosting" Version="0.2.0-alpha.179" />
     <PackageReference Include="OpenTelemetry.Exporter.NewRelic" Version="1-*" />
   </ItemGroup>
 </Project>

--- a/src/IntegrationTests/Applications/SampleAspNetCoreApp/Startup.cs
+++ b/src/IntegrationTests/Applications/SampleAspNetCoreApp/Startup.cs
@@ -9,7 +9,6 @@ using OpenTelemetry.Collector.AspNetCore;
 using OpenTelemetry.Collector.Dependencies;
 using OpenTelemetry.Exporter.NewRelic;
 using OpenTelemetry.Trace.Configuration;
-using OpenTelemetry.Trace.Sampler;
 
 namespace SampleAspNetCoreApp
 {
@@ -34,8 +33,7 @@ namespace SampleAspNetCoreApp
                 var loggerFactory = svcProvider.GetRequiredService<ILoggerFactory>();
 
                 // Adds the New Relic Exporter loading settings from the appsettings.json
-                var tracerFactory = TracerFactory.Create(b => b.UseNewRelic(Configuration, loggerFactory)
-                                                 .SetSampler(Samplers.AlwaysSample));
+                var tracerFactory = TracerFactory.Create(b => b.UseNewRelic(Configuration, loggerFactory));
 
                 var dependenciesCollector = new DependenciesCollector(new HttpClientCollectorOptions(), tracerFactory);
                 var aspNetCoreCollector = new AspNetCoreCollector(tracerFactory.GetTracer(null));

--- a/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
+++ b/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Collector.AspNetCore" Version="0.2.0-alpha.100" />
-    <PackageReference Include="OpenTelemetry.Collector.Dependencies" Version="0.2.0-alpha.100" />
-    <PackageReference Include="OpenTelemetry.Hosting" Version="0.2.0-alpha.100" />
+    <PackageReference Include="OpenTelemetry.Collector.AspNetCore" Version="0.2.0-alpha.179" />
+    <PackageReference Include="OpenTelemetry.Collector.Dependencies" Version="0.2.0-alpha.179" />
+    <PackageReference Include="OpenTelemetry.Hosting" Version="0.2.0-alpha.179" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/Global.asax.cs
+++ b/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/Global.asax.cs
@@ -3,7 +3,6 @@ using System.Web.Http;
 using OpenTelemetry.Collector.Dependencies;
 using OpenTelemetry.Trace.Configuration;
 using OpenTelemetry.Exporter.NewRelic;
-using OpenTelemetry.Trace.Sampler;
 using OpenTelemetry.Trace;
 
 namespace SampleAspNetFrameworkApp
@@ -11,7 +10,7 @@ namespace SampleAspNetFrameworkApp
     public class WebApiApplication : System.Web.HttpApplication
     {
         // Static handle to the OpenTelemetry Tracer
-        public static ITracer OTTracer;
+        public static Tracer OTTracer;
 
         protected void Application_Start()
         {
@@ -24,8 +23,7 @@ namespace SampleAspNetFrameworkApp
             var tracerFactory = TracerFactory.Create((b) =>
             {
                 b.UseNewRelic(apiKey)
-                .AddDependencyCollector()
-                .SetSampler(Samplers.AlwaysSample);
+                .AddDependencyCollector();
             });
 
             var dependenciesCollector = new DependenciesCollector(new HttpClientCollectorOptions(), tracerFactory);

--- a/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/SampleAspNetFrameworkApp.csproj
+++ b/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/SampleAspNetFrameworkApp.csproj
@@ -87,16 +87,16 @@
       <HintPath>..\..\packages\Microsoft.Extensions.Primitives.2.1.0\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="OpenTelemetry, Version=0.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\OpenTelemetry.0.2.0-alpha.100\lib\net46\OpenTelemetry.dll</HintPath>
+      <HintPath>..\..\packages\OpenTelemetry.0.2.0-alpha.179\lib\net46\OpenTelemetry.dll</HintPath>
     </Reference>
     <Reference Include="OpenTelemetry.Api, Version=0.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\OpenTelemetry.Api.0.2.0-alpha.100\lib\net45\OpenTelemetry.Api.dll</HintPath>
+      <HintPath>..\..\packages\OpenTelemetry.Api.0.2.0-alpha.179\lib\net45\OpenTelemetry.Api.dll</HintPath>
     </Reference>
     <Reference Include="OpenTelemetry.Collector.Dependencies, Version=0.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\OpenTelemetry.Collector.Dependencies.0.2.0-alpha.100\lib\netstandard2.0\OpenTelemetry.Collector.Dependencies.dll</HintPath>
+      <HintPath>..\..\packages\OpenTelemetry.Collector.Dependencies.0.2.0-alpha.179\lib\netstandard2.0\OpenTelemetry.Collector.Dependencies.dll</HintPath>
     </Reference>
     <Reference Include="OpenTelemetry.Hosting, Version=0.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\OpenTelemetry.Hosting.0.2.0-alpha.100\lib\netstandard2.0\OpenTelemetry.Hosting.dll</HintPath>
+      <HintPath>..\..\packages\OpenTelemetry.Hosting.0.2.0-alpha.179\lib\netstandard2.0\OpenTelemetry.Hosting.dll</HintPath>
     </Reference>
     <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Buffers.4.4.0\lib\netstandard2.0\System.Buffers.dll</HintPath>

--- a/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/packages.config
+++ b/src/OpenTelemetry.Exporter.NewRelic.Samples/SampleAspNetFrameworkApp/packages.config
@@ -20,10 +20,10 @@
   <package id="Microsoft.Extensions.Options" version="2.1.0" targetFramework="net47" />
   <package id="Microsoft.Extensions.Primitives" version="2.1.0" targetFramework="net47" />
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net47" />
-  <package id="OpenTelemetry" version="0.2.0-alpha.100" targetFramework="net47" />
-  <package id="OpenTelemetry.Api" version="0.2.0-alpha.100" targetFramework="net47" />
-  <package id="OpenTelemetry.Collector.Dependencies" version="0.2.0-alpha.100" targetFramework="net47" />
-  <package id="OpenTelemetry.Hosting" version="0.2.0-alpha.100" targetFramework="net47" />
+  <package id="OpenTelemetry" version="0.2.0-alpha.179" targetFramework="net47" />
+  <package id="OpenTelemetry.Api" version="0.2.0-alpha.179" targetFramework="net47" />
+  <package id="OpenTelemetry.Collector.Dependencies" version="0.2.0-alpha.179" targetFramework="net47" />
+  <package id="OpenTelemetry.Hosting" version="0.2.0-alpha.179" targetFramework="net47" />
   <package id="System.Buffers" version="4.4.0" targetFramework="net47" />
   <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net47" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.6.0" targetFramework="net47" />

--- a/src/OpenTelemetry.Exporter.NewRelic.Tests/OpenTelemetry.Exporter.NewRelic.Tests.csproj
+++ b/src/OpenTelemetry.Exporter.NewRelic.Tests/OpenTelemetry.Exporter.NewRelic.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="OpenTelemetry" Version="0.2.0-alpha.100" />
+    <PackageReference Include="OpenTelemetry" Version="0.2.0-alpha.179" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Exporter.NewRelic.Tests/SpanConverterTests.cs
+++ b/src/OpenTelemetry.Exporter.NewRelic.Tests/SpanConverterTests.cs
@@ -1,33 +1,52 @@
 using NUnit.Framework;
 using OpenTelemetry.Trace;
 using OpenTelemetry.Trace.Configuration;
-using System.Threading;
 using System.Linq;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NewRelic.Telemetry;
-using NRSpans = NewRelic.Telemetry.Spans;
-
+using NewRelic.Telemetry.Spans;
+using System;
 
 namespace OpenTelemetry.Exporter.NewRelic.Tests
-{ 
+{
     public class SpanConverterTests
-	{
+    {
         const string testServiceName = "TestService";
         const string errorMessage = "This is a test error description";
 
         const int expected_CountSpans = 4;
 
-        private List<ISpan> _otSpans = new List<ISpan>();
-        private List<NRSpans.Span> _resultNRSpans = new List<NRSpans.Span>();
+        private List<TelemetrySpan> _otSpans = new List<TelemetrySpan>();
+        private List<Span> _resultNRSpans = new List<Span>();
 
-        private Dictionary<string, NRSpans.Span> resultNRSpansDic => _resultNRSpans.ToDictionary(x => x.Id);
+        private Dictionary<string, Span> resultNRSpansDic => _resultNRSpans.ToDictionary(x => x.Id);
+
+        //  Creating the following spans                        Trace       Expected Outcome
+        //  -----------------------------------------------------------------------------------
+        //  0   Test Span 1                                     Trace 1     Included
+        //  1       Test Span 2                                 Trace 1     Included
+        //  2   Test Span 3                                     Trace 2     Included
+        //  3   Test Span 4                                     Trace 3     Included
+        //  4       Shoul be Filtered - HTTP Call to NR         Trace 3     Excluded
+        //  5           Should be filtered - Child of HTTP      Trace 3     Excluded
+
+        private static DateTimeOffset _traceStartTime = DateTime.UtcNow;
+        private (int? Parent, string Name, DateTimeOffset Start, DateTimeOffset End, Status Status)[] spanDefinitions = new (int?, string, DateTimeOffset, DateTimeOffset, Status)[]
+        {
+            (null, "Test Span 1", _traceStartTime, _traceStartTime.AddMilliseconds(225), Status.Ok ),
+            (0, "Test Span 2", _traceStartTime.AddMilliseconds(1), _traceStartTime.AddMilliseconds(100), Status.Aborted.WithDescription(errorMessage) ),
+            (null, "Test Span 3", _traceStartTime.AddMilliseconds(2), _traceStartTime.AddMilliseconds(375), Status.Ok ),
+            (null, "Test Span 4", _traceStartTime.AddMilliseconds(3), _traceStartTime.AddMilliseconds(650), Status.Ok ),
+            (3, "Should Be Filtered - HTTP Call to NR", _traceStartTime.AddMilliseconds(4), _traceStartTime.AddMilliseconds(600), Status.Ok ),
+            (4, "Should Be Filtered - Child of HTTP", _traceStartTime.AddMilliseconds(5), _traceStartTime.AddMilliseconds(500), Status.Ok ),
+        };
 
         [SetUp]
-		public void Setup()
-		{
+        public void Setup()
+        {
             var config = new TelemetryConfiguration().WithApiKey("123456").WithServiceName(testServiceName);
-            var mockDataSender = new NRSpans.SpanDataSender(config);
+            var mockDataSender = new SpanDataSender(config);
 
             //Capture the spans that were requested to be sent to New Relic.
             mockDataSender.WithCaptureSendDataAsyncDelegate((sb, retryId) =>
@@ -49,41 +68,16 @@ namespace OpenTelemetry.Exporter.NewRelic.Tests
             {
                 var tracer = tracerFactory.GetTracer("TestTracer");
 
-                //  Creating the following spans                        Trace       Expected Outcome
-                //  -----------------------------------------------------------------------------------
-                //  0   Test Span 1                                     Trace 1     Included
-                //  1       Test Span 2                                 Trace 1     Included
-                //  2   Test Span 3                                     Trace 2     Included
-                //  3   Test Span 4                                     Trace 3     Included
-                //  4       Shoul be Filtered - HTTP Call to NR         Trace 3     Excluded
-                //  5           Should be filtered - Child of HTTP      Trace 3     Excluded
-
-                _otSpans.Add(tracer.StartRootSpan("Test Span 1"));
-                _otSpans.Add(tracer.StartSpan("Test Span 2", _otSpans[0]));
-                _otSpans.Add(tracer.StartRootSpan("Test Span 3"));
-                _otSpans.Add(tracer.StartRootSpan("Test Span 4"));
-                _otSpans.Add(tracer.StartSpan("Should Be Filtered - HTTP Call to NR",_otSpans[3]).PutHttpRawUrlAttribute(config.TraceUrl));
-                _otSpans.Add(tracer.StartSpan("Should Be Filtered - Child of HTTP", _otSpans[4]));
-                
-                _otSpans[0].Status = Status.Ok;
-                _otSpans[1].Status = Status.Aborted.WithDescription(errorMessage);
-                _otSpans[2].Status = Status.Ok;
-                _otSpans[3].Status = Status.Ok;
-                _otSpans[4].Status = Status.Ok;
-                _otSpans[5].Status = Status.Ok;
-
-                Thread.Sleep(100);
-                _otSpans[1].End();
-                Thread.Sleep(125);
-                _otSpans[0].End();
-                Thread.Sleep(150);
-                _otSpans[2].End();
-                Thread.Sleep(175);
-                _otSpans[5].End();
-                Thread.Sleep(100);
-                _otSpans[4].End();
-                Thread.Sleep(50);
-                _otSpans[3].End();
+                for (var i = 0; i < spanDefinitions.Length; ++i)
+                {
+                    var spanDefinition = spanDefinitions[i];
+                    var span = !spanDefinition.Parent.HasValue
+                        ? tracer.StartRootSpan(spanDefinition.Name, SpanKind.Server, new SpanCreationOptions { StartTimestamp = spanDefinition.Start })
+                        : tracer.StartSpan(spanDefinition.Name, SpanKind.Server, new SpanCreationOptions { StartTimestamp = spanDefinition.Start });
+                    span.Status = spanDefinition.Status;
+                    span.End(spanDefinition.End);
+                    _otSpans.Add(span);
+                }
             }
         }
 
@@ -95,8 +89,8 @@ namespace OpenTelemetry.Exporter.NewRelic.Tests
         }
 
         [Test]
-		public void Test_ExpectedSpansCreated()
-		{
+        public void Test_ExpectedSpansCreated()
+        {
             Assert.AreEqual(expected_CountSpans, resultNRSpansDic.Count, "Unexpected number of spans");
 
             var resultNRSpan0 = resultNRSpansDic[_otSpans[0].Context.SpanId.ToHexString()];
@@ -150,7 +144,7 @@ namespace OpenTelemetry.Exporter.NewRelic.Tests
             var resultNRSpan2 = resultNRSpansDic[_otSpans[2].Context.SpanId.ToHexString()];
             var resultNRSpan3 = resultNRSpansDic[_otSpans[3].Context.SpanId.ToHexString()];
 
-            Assert.IsNull(resultNRSpan0.ParentId,"Top Level Span should have NULL parentID");
+            Assert.IsNull(resultNRSpan0.ParentId, "Top Level Span should have NULL parentID");
             Assert.AreEqual(resultNRSpan1.ParentId, resultNRSpan0.Id, "Mismatch on ParentId - Span1 is a child of Span0");
             Assert.IsNull(resultNRSpan2.ParentId, "Top Level Span should have NULL parentID");
             Assert.IsNull(resultNRSpan3.ParentId, "Top Level Span should have NULL parentID");
@@ -167,20 +161,18 @@ namespace OpenTelemetry.Exporter.NewRelic.Tests
         [Test]
         public void Test_Timestamps()
         {
-            foreach (var otISpan in _otSpans)
+            for (var i = 0; i < _otSpans.Count; ++i)
             {
-                var otSpan = otISpan as Span;
-
-                if (!resultNRSpansDic.TryGetValue(otSpan.Context.SpanId.ToHexString(), out var nrSpan))
+                if (!resultNRSpansDic.TryGetValue(_otSpans[i].Context.SpanId.ToHexString(), out var nrSpan))
                 {
                     continue;
                 }
 
-                var expectedStartTimestampUnixMs = otSpan.StartTimestamp.ToUnixTimeMilliseconds();
-                var expectedEndTimestampUnixMs = otSpan.EndTimestamp.ToUnixTimeMilliseconds();
+                var expectedStartTimestampUnixMs = spanDefinitions[i].Start.ToUnixTimeMilliseconds();
+                var expectedEndTimestampUnixMs = spanDefinitions[i].End.ToUnixTimeMilliseconds();
                 var expectedDurationMs = expectedEndTimestampUnixMs - expectedStartTimestampUnixMs;
 
-                Assert.AreEqual(expectedStartTimestampUnixMs, nrSpan.Timestamp, $"{otSpan.Name} - Open Telemetry StartTime should translate to {expectedStartTimestampUnixMs}");
+                Assert.AreEqual(expectedStartTimestampUnixMs, nrSpan.Timestamp, $"{spanDefinitions[i].Name} - Open Telemetry StartTime should translate to {expectedStartTimestampUnixMs}");
                 Assert.AreEqual(expectedDurationMs, nrSpan.Attributes["duration.ms"]);
             }
         }
@@ -188,10 +180,8 @@ namespace OpenTelemetry.Exporter.NewRelic.Tests
         [Test]
         public void Test_InstrumentationProvider()
         {
-            foreach (var otISpan in _otSpans)
+            foreach (var otSpan in _otSpans)
             {
-                var otSpan = otISpan as Span;
-
                 if (!resultNRSpansDic.TryGetValue(otSpan.Context.SpanId.ToHexString(), out var nrSpan))
                 {
                     continue;

--- a/src/OpenTelemetry.Exporter.NewRelic/OpenTelemetry.Exporter.NewRelic.csproj
+++ b/src/OpenTelemetry.Exporter.NewRelic/OpenTelemetry.Exporter.NewRelic.csproj
@@ -35,7 +35,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.0" />
-    <PackageReference Include="OpenTelemetry" Version="0.2.0-alpha.100" />
+    <PackageReference Include="OpenTelemetry" Version="0.2.0-alpha.179" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
0.2.0-alpha.179 is the currently published version of OpenTelemetry nuget packages.

Changes that impacted us were mostly made in this PR: https://github.com/open-telemetry/opentelemetry-dotnet/pull/420. Great discussion in that PR describing the theory behind the changes.

More breaking changes likely in the next version pushed to nuget. I'll evaluate this.