### PR TITLE
Perform SonarCloud analysis only on builds from master

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,7 +105,7 @@ steps:
       )
     )
   displayName: "SonarCloud - Validate Quality Gate Results"
-  condition: and ( succeeded(), eq(variables['Build.Reason'], 'PullRequest'), eq(variables['System.PullRequest.TargetBranch'], 'master'))
+  # condition: and ( succeeded(), eq(variables['Build.Reason'], 'PullRequest'), eq(variables['System.PullRequest.TargetBranch'], 'master'))
   inputs:
     SonarCloud: 'SonarCloud'
     organization: '$(SonarCloudOrganization)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,14 @@ steps:
     restoreSolution: 'src/NewRelic.Telemetry.sln' 
 
 - task: SonarCloudPrepare@1
+  condition: |
+    and (
+      succeeded(),
+      or (
+        eq(variables['Build.SourceBranch'], 'refs/heads/master'),
+        startsWith(variables['Build.SourceBranch'], 'refs/tags')
+      )
+    )
   displayName: 'SonarCloud - Prepare for Analysis'
   inputs:
     SonarCloud: 'SonarCloud'
@@ -66,12 +74,36 @@ steps:
     targetFolder: '$(Build.ArtifactStagingDirectory)/OpenTelemetry'
 
 - task: SonarCloudAnalyze@1
+  condition: |
+    and (
+      succeeded(),
+      or (
+        eq(variables['Build.SourceBranch'], 'refs/heads/master'),
+        startsWith(variables['Build.SourceBranch'], 'refs/tags')
+      )
+    )
   displayName: 'SonarCloud - Code analysis'
 
 - task: SonarCloudPublish@1
+  condition: |
+    and (
+      succeeded(),
+      or (
+        eq(variables['Build.SourceBranch'], 'refs/heads/master'),
+        startsWith(variables['Build.SourceBranch'], 'refs/tags')
+      )
+    )
   displayName: 'SonarCloud - Publish Quality Gate Results'
   
 - task: sonarcloud-buildbreaker@2
+  condition: |
+    and (
+      succeeded(),
+      or (
+        eq(variables['Build.SourceBranch'], 'refs/heads/master'),
+        startsWith(variables['Build.SourceBranch'], 'refs/tags')
+      )
+    )
   displayName: "SonarCloud - Validate Quality Gate Results"
   condition: and ( succeeded(), eq(variables['Build.Reason'], 'PullRequest'), eq(variables['System.PullRequest.TargetBranch'], 'master'))
   inputs:


### PR DESCRIPTION
Excluding SonarCloud analysis from PR builds. It does not seem that it can be done from externally submitted PRs. I think this is a relevant feature request: https://jira.sonarsource.com/browse/MMF-1371.

Side note: We keep copy/pasting the same condition all over the `azure-pipeline.yml` file. Makes me think we need to explore different pipelines for different purposes, or maybe there's a different solution? ... Punting on this for now.