### PR TITLE
Add sample console app

### DIFF
--- a/NewRelic.sln
+++ b/NewRelic.sln
@@ -63,6 +63,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{2C3BDC5D
 		tests\Directory.Build.props = tests\Directory.Build.props
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NewRelic.Examples.ConsoleCore", "examples\OpenTelemetry.Exporter.NewRelic\ConsoleCore\NewRelic.Examples.ConsoleCore.csproj", "{E3B2A227-C536-4DF7-9882-19EC54D6EED3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -181,6 +183,18 @@ Global
 		{2002CE3F-509D-4992-88AF-A4D5B306E16F}.Release|x64.Build.0 = Release|Any CPU
 		{2002CE3F-509D-4992-88AF-A4D5B306E16F}.Release|x86.ActiveCfg = Release|Any CPU
 		{2002CE3F-509D-4992-88AF-A4D5B306E16F}.Release|x86.Build.0 = Release|Any CPU
+		{E3B2A227-C536-4DF7-9882-19EC54D6EED3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E3B2A227-C536-4DF7-9882-19EC54D6EED3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E3B2A227-C536-4DF7-9882-19EC54D6EED3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E3B2A227-C536-4DF7-9882-19EC54D6EED3}.Debug|x64.Build.0 = Debug|Any CPU
+		{E3B2A227-C536-4DF7-9882-19EC54D6EED3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E3B2A227-C536-4DF7-9882-19EC54D6EED3}.Debug|x86.Build.0 = Debug|Any CPU
+		{E3B2A227-C536-4DF7-9882-19EC54D6EED3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E3B2A227-C536-4DF7-9882-19EC54D6EED3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E3B2A227-C536-4DF7-9882-19EC54D6EED3}.Release|x64.ActiveCfg = Release|Any CPU
+		{E3B2A227-C536-4DF7-9882-19EC54D6EED3}.Release|x64.Build.0 = Release|Any CPU
+		{E3B2A227-C536-4DF7-9882-19EC54D6EED3}.Release|x86.ActiveCfg = Release|Any CPU
+		{E3B2A227-C536-4DF7-9882-19EC54D6EED3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -195,6 +209,7 @@ Global
 		{D847E466-5836-4FBA-9D1A-8DF1FD9EF5A8} = {A76FE35F-7402-4B7D-BA8A-9DE4B1C63102}
 		{697E652D-2BAC-4CA6-80EF-78465A796AAC} = {E4E6AA6F-E52E-4D98-8A93-70F6872E03FA}
 		{2C3BDC5D-1E8E-4A17-B2B6-E4950DACBBE5} = {E4E6AA6F-E52E-4D98-8A93-70F6872E03FA}
+		{E3B2A227-C536-4DF7-9882-19EC54D6EED3} = {6B78F9B1-C192-45E1-8E33-CB2A71CA3E1E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {08D1630D-EA85-4E78-ABBA-34195DCA7595}

--- a/examples/OpenTelemetry.Exporter.NewRelic/ConsoleCore/NewRelic.Examples.ConsoleCore.csproj
+++ b/examples/OpenTelemetry.Exporter.NewRelic/ConsoleCore/NewRelic.Examples.ConsoleCore.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="0.6.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="0.7.0-beta.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/OpenTelemetry.Exporter.NewRelic/ConsoleCore/NewRelic.Examples.ConsoleCore.csproj
+++ b/examples/OpenTelemetry.Exporter.NewRelic/ConsoleCore/NewRelic.Examples.ConsoleCore.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="0.6.0-beta.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\OpenTelemetry.Exporter.NewRelic\OpenTelemetry.Exporter.NewRelic.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/OpenTelemetry.Exporter.NewRelic/ConsoleCore/Program.cs
+++ b/examples/OpenTelemetry.Exporter.NewRelic/ConsoleCore/Program.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Diagnostics;
+using System.Net.Http;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+namespace SampleConsoleCoreApp
+{
+    class Program
+    {
+        private const string ActivitySourceName = "NewRelic.OpenTelemetryExporter.SampleConsoleCoreApp";
+        private static readonly ActivitySource SampleActivitySource = new ActivitySource(ActivitySourceName);
+
+        // Set these values for yourself
+        private const string MyNewRelicInsightsInsertApiKey = "<YOUR_NR_INSIGHTS_INSERT_API_KEY_HERE>";
+        private const string MyServiceName = "SampleConsoleCoreApp";
+
+        static void Main(string[] args)
+        {
+            var loggerFactory = LoggerFactory.Create(builder =>
+                {
+                    builder.SetMinimumLevel(LogLevel.Debug)
+                           .AddConsole();
+                }
+            );
+
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .AddSource(ActivitySourceName)
+                .AddNewRelicExporter(options =>
+                {
+                    options.ApiKey = MyNewRelicInsightsInsertApiKey;
+                    options.ServiceName = MyServiceName;
+                    options.AuditLoggingEnabled = true;
+                }, loggerFactory)
+                .AddHttpClientInstrumentation()
+                .Build();
+
+            using (var activity = SampleActivitySource.StartActivity("SampleConsoleCoreAppSpan"))
+            {
+                Console.WriteLine("Creating root of trace.");
+
+                var message = "Hello, OpenTelemetry with New Relic!";
+                activity?.SetTag("aNumber", 42);
+                activity?.SetTag("message", message);
+
+                Console.WriteLine("\nMaking an external HTTP request which will be added as a child span of the trace.");
+
+                var httpClient = new HttpClient();
+                var request = httpClient.GetAsync("https://www.newrelic.com");
+
+                Console.WriteLine($"Web request result: {request.Result.StatusCode}");
+            }
+
+            Console.WriteLine("\nTrace finished, waiting ten seconds to allow trace to be collected and sent to New Relic.");
+            System.Threading.Thread.Sleep(10000);
+        }
+    }
+}


### PR DESCRIPTION
Resolves #140 by adding a `netcoreapp3.0` console application which demonstrates using our OpenTelemetry exporter to send a simple OpenTelemetry trace to New Relic, provided an appropriate API key.