### PR TITLE
Creates New Relic Open Telemetry exporter configuration options.

### DIFF
--- a/src/NewRelic.OpenTelemetry/NewRelicExporterHelperExtensions.cs
+++ b/src/NewRelic.OpenTelemetry/NewRelicExporterHelperExtensions.cs
@@ -5,7 +5,6 @@ using System;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using NewRelic.OpenTelemetry;
-using NewRelic.Telemetry;
 
 namespace OpenTelemetry.Trace
 {
@@ -18,29 +17,29 @@ namespace OpenTelemetry.Trace
         /// Adds New Relic exporter to the TracerProvider.
         /// </summary>
         /// <param name="builder"><see cref="TracerProviderBuilder"/> builder to use.</param>
-        /// <param name="configure">Exporter configuration options.</param>
+        /// <param name="options">Exporter configuration options.</param>
         /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
-        public static TracerProviderBuilder AddNewRelicExporter(this TracerProviderBuilder builder, Action<TelemetryConfiguration> configure)
+        public static TracerProviderBuilder AddNewRelicExporter(this TracerProviderBuilder builder, Action<NewRelicExporterOptions> options)
         {
-            return AddNewRelicExporter(builder, configure, null!);
+            return AddNewRelicExporter(builder, options, null!);
         }
 
         /// <summary>
         /// Adds New Relic exporter to the TracerProvider and enables the exporter to log to an ILogger.
         /// </summary>
         /// <param name="builder"><see cref="TracerProviderBuilder"/> builder to use.</param>
-        /// <param name="configure">Exporter configuration options.</param>
+        /// <param name="options">Exporter configuration options.</param>
         /// <param name="loggerFactory">ILoggerFactory instance for creating an ILogger.</param>
         /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
-        public static TracerProviderBuilder AddNewRelicExporter(this TracerProviderBuilder builder, Action<TelemetryConfiguration> configure, ILoggerFactory loggerFactory)
+        public static TracerProviderBuilder AddNewRelicExporter(this TracerProviderBuilder builder, Action<NewRelicExporterOptions> options, ILoggerFactory loggerFactory)
         {
             if (builder == null)
             {
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            var config = new TelemetryConfiguration();
-            configure?.Invoke(config);
+            var config = new NewRelicExporterOptions();
+            options?.Invoke(config);
             var exporter = new NewRelicTraceExporter(config, loggerFactory);
 
             return builder.AddProcessor(new BatchExportProcessor<Activity>(exporter));

--- a/src/NewRelic.OpenTelemetry/NewRelicExporterOptions.cs
+++ b/src/NewRelic.OpenTelemetry/NewRelicExporterOptions.cs
@@ -1,0 +1,72 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using NewRelic.Telemetry;
+
+namespace NewRelic.OpenTelemetry
+{
+    /// <summary>
+    /// New Relic Exporter options.
+    /// </summary>
+    public class NewRelicExporterOptions
+    {
+        /// <summary>
+        /// REQUIRED: Your Insights Insert API Key.  This value is required in order to communicate with the
+        /// New Relic Endpoint. 
+        /// </summary>
+        /// <see cref="https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/introduction-event-api#register">for more information.</see>
+        public string? ApiKey
+        {
+            get => TelemetryConfiguration.ApiKey;
+            set => TelemetryConfiguration.ApiKey = value;
+        }
+
+        /// <summary>
+        /// The New Relic endpoint where information is sent.
+        /// </summary>
+        public Uri EndpointUrl
+        {
+            get => TelemetryConfiguration.TraceUrl;
+            set => TelemetryConfiguration.TraceUrl = value;
+        }
+
+        /// <summary>
+        /// Logs messages sent-to and received-by the New Relic endpoints.  This setting
+        /// is useful for troubleshooting, but is not recommended in production environments.
+        /// </summary>
+        public bool AuditLoggingEnabled
+        {
+            get => TelemetryConfiguration.AuditLoggingEnabled;
+            set => TelemetryConfiguration.AuditLoggingEnabled = value;
+        }
+
+        /// <summary>
+        /// Identifies the name of a service for which information is being reported to New Relic.
+        /// </summary>
+        public string? ServiceName
+        {
+            get => TelemetryConfiguration.ServiceName;
+            set => TelemetryConfiguration.ServiceName = value;
+        }
+
+        /// <summary>
+        /// Identifies the source of information that is being sent to New Relic.
+        /// </summary>
+        public string? InstrumentationProvider
+        {
+            get => TelemetryConfiguration.InstrumentationProvider;
+            set => TelemetryConfiguration.InstrumentationProvider = value;
+        }
+
+        internal TelemetryConfiguration TelemetryConfiguration { get; } = new TelemetryConfiguration();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NewRelicExporterOptions"/> class.
+        /// Creates the Options object accepting all default settings.
+        /// </summary>
+        public NewRelicExporterOptions()
+        {
+        }
+    }
+}

--- a/src/NewRelic.OpenTelemetry/NewRelicTraceExporter.cs
+++ b/src/NewRelic.OpenTelemetry/NewRelicTraceExporter.cs
@@ -33,31 +33,31 @@ namespace NewRelic.OpenTelemetry
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NewRelicTraceExporter"/> class.
-        /// Configures the Trace Exporter accepting configuration settings from an instance of the New Relic Telemetry SDK configuration object.
+        /// Configures the Trace Exporter accepting configuration settings from an instance of the New Relic Exporter options object.
         /// </summary>
-        /// <param name="config"></param>
-        public NewRelicTraceExporter(TelemetrySdk.TelemetryConfiguration config)
-            : this(config, null!)
+        /// <param name="options"></param>
+        public NewRelicTraceExporter(NewRelicExporterOptions options)
+            : this(options, null!)
         {
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NewRelicTraceExporter"/> class.
-        /// Configures the Trace Exporter accepting configuration settings from an instance of the New Relic Telemetry SDK configuration object.  Also
+        /// Configures the Trace Exporter accepting configuration settings from an instance of the New Relic Exporter options object.  Also
         /// accepts a logger factory supported by Microsoft.Extensions.Logging.
         /// </summary>
-        /// <param name="config"></param>
-        public NewRelicTraceExporter(TelemetrySdk.TelemetryConfiguration config, ILoggerFactory loggerFactory)
-            : this(new TraceDataSender(config, loggerFactory), config, loggerFactory)
+        /// <param name="options"></param>
+        public NewRelicTraceExporter(NewRelicExporterOptions options, ILoggerFactory loggerFactory)
+            : this(new TraceDataSender(options.TelemetryConfiguration, loggerFactory), options, loggerFactory)
         {
         }
 
-        internal NewRelicTraceExporter(TraceDataSender spanDataSender, TelemetrySdk.TelemetryConfiguration config, ILoggerFactory? loggerFactory)
+        internal NewRelicTraceExporter(TraceDataSender spanDataSender, NewRelicExporterOptions options, ILoggerFactory? loggerFactory)
         {
             _spanDataSender = spanDataSender;
             spanDataSender.AddVersionInfo(ProductName, _productVersion);
 
-            _config = config;
+            _config = options.TelemetryConfiguration;
 
             _config.InstrumentationProvider = "opentelemetry";
 

--- a/src/NewRelic.Telemetry/TelemetryConfiguration.cs
+++ b/src/NewRelic.Telemetry/TelemetryConfiguration.cs
@@ -11,7 +11,12 @@ namespace NewRelic.Telemetry
     /// <summary>
     /// Configuration settings for the New Relic Telemetry SDK.
     /// </summary>
-    public class TelemetryConfiguration
+#if INTERNALIZE_TELEMETRY_SDK
+    internal
+#else
+    public
+#endif
+    class TelemetryConfiguration
     {
         /// <summary>
         /// REQUIRED: Your Insights Insert API Key.  This value is required in order to communicate with the

--- a/tests/NewRelic.OpenTelemetry.Tests/NewRelicExporterTests.cs
+++ b/tests/NewRelic.OpenTelemetry.Tests/NewRelicExporterTests.cs
@@ -6,7 +6,6 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
-using NewRelic.Telemetry;
 using OpenTelemetry;
 using OpenTelemetry.Trace;
 using Xunit;
@@ -79,11 +78,11 @@ namespace NewRelic.OpenTelemetry.Tests
                     endCalledCount++;
                 };
 
-            var exporterOptions = new TelemetryConfiguration()
+            var exporterOptions = new NewRelicExporterOptions()
             {
                 ApiKey = "my-apikey",
                 ServiceName = "test-newrelic",
-                TraceUrl = new Uri($"http://{_testServerHost}:{_testServerPort}/trace/v1?requestId={requestId}"),
+                EndpointUrl = new Uri($"http://{_testServerHost}:{_testServerPort}/trace/v1?requestId={requestId}"),
             };
 
             var newRelicExporter = new NewRelicTraceExporter(exporterOptions);


### PR DESCRIPTION
- Defines a smaller set of configuration options for the New Relic Open Telemetry Exporter.
- Makes the Telemetry SDK configuration internal, when used within the context of the Open Telemetry Exporter.