### PR TITLE
Remove error attribute

### DIFF
--- a/examples/NewRelic.Telemetry/AspNet/Controllers/WeatherForecastController.cs
+++ b/examples/NewRelic.Telemetry/AspNet/Controllers/WeatherForecastController.cs
@@ -80,7 +80,6 @@ namespace ASPNetFrameworkApiApplication.Controllers
             // If an unhandled exception occurs, it can be denoted on the span.
             catch (Exception ex)
             {
-                spanAttribs[NewRelicConsts.Tracing.AttribNameHasError] = true;
                 spanAttribs[NewRelicConsts.Tracing.AttribNameErrorMsg] = ex;
 
                 //This ensures that tracking of spans doesn't interfere with the normal execution flow

--- a/examples/NewRelic.Telemetry/AspNetCore/Controllers/WeatherForecastController.cs
+++ b/examples/NewRelic.Telemetry/AspNetCore/Controllers/WeatherForecastController.cs
@@ -62,7 +62,6 @@ namespace AspNetCoreWebApiApplication.Controllers
             // If an unhandled exception occurs, it can be denoted on the span.
             catch (Exception ex)
             {
-                spanAttribs[NewRelicConsts.Tracing.AttribNameHasError] = true;
                 spanAttribs[NewRelicConsts.Tracing.AttribNameErrorMsg] = ex;
 
                 //This ensures that tracking of spans doesn't interfere with the normal execution flow

--- a/examples/NewRelic.Telemetry/Console/Program.cs
+++ b/examples/NewRelic.Telemetry/Console/Program.cs
@@ -79,8 +79,7 @@ namespace BasicConsoleApplication
                     // In the event of an exception, mark the span 
                     // as having an error and record a custom attribute 
                     // with the details about the exception.
-                    spanAttribs[NewRelicConsts.Tracing.AttribNameHasError] = true;
-                    spanAttribs[NewRelicConsts.Tracing.AttribNameHasError] = ex;
+                    spanAttribs[NewRelicConsts.Tracing.AttribNameErrorMsg] = ex.Message;
                 }
                 finally
                 {
@@ -138,8 +137,7 @@ namespace BasicConsoleApplication
                         // In the event of an exception, mark the span 
                         // as having an error and record a custom attribute 
                         // with the details about the exception.
-                        spanAttribs[NewRelicConsts.Tracing.AttribNameHasError] = true;
-                        spanAttribs[NewRelicConsts.Tracing.AttribNameHasError] = ex;
+                        spanAttribs[NewRelicConsts.Tracing.AttribNameErrorMsg] = ex.Message;
                     }
                     finally
                     {

--- a/src/NewRelic.OpenTelemetry/NewRelicTraceExporter.cs
+++ b/src/NewRelic.OpenTelemetry/NewRelicTraceExporter.cs
@@ -167,8 +167,6 @@ namespace NewRelic.OpenTelemetry
             var status = openTelemetrySpan.GetStatus();
             if (!status.IsOk)
             {
-                newRelicSpanAttribs.Add(NewRelicConsts.Tracing.AttribNameHasError, true);
-
                 if (!string.IsNullOrWhiteSpace(status.Description))
                 {
                     newRelicSpanAttribs.Add(NewRelicConsts.Tracing.AttribNameErrorMsg, status.Description);

--- a/src/NewRelic.Telemetry/NewRelicConsts.cs
+++ b/src/NewRelic.Telemetry/NewRelicConsts.cs
@@ -19,7 +19,6 @@ namespace NewRelic.Telemetry
             public const string AttribNameDurationMs = "duration.ms";
             public const string AttribNameName = "name";
             public const string AttribNameParentId = "parent.id";
-            public const string AttribNameHasError = "error";
             public const string AttribNameErrorMsg = "error.message";
             public const string AttribNameHttpUrl = "http.url";
         }

--- a/tests/NewRelic.OpenTelemetry.Tests/SpanConverterTests.cs
+++ b/tests/NewRelic.OpenTelemetry.Tests/SpanConverterTests.cs
@@ -131,18 +131,17 @@ namespace NewRelic.OpenTelemetry.Tests
         }
 
         [Fact]
-        public void Test_ErrorAttribute()
+        public void Test_ErrorMessageAttribute()
         {
             var resultSpan0 = ResultNRSpansDic[_otSpans[0].Context.SpanId.ToHexString()];
             var resultSpan1 = ResultNRSpansDic[_otSpans[1].Context.SpanId.ToHexString()];
             var resultSpan2 = ResultNRSpansDic[_otSpans[2].Context.SpanId.ToHexString()];
             var resultSpan3 = ResultNRSpansDic[_otSpans[3].Context.SpanId.ToHexString()];
 
-            Assert.False(resultSpan0.Attributes?.ContainsKey("error"));
-            Assert.True((bool?)resultSpan1.Attributes?["error"]);
+            Assert.False(resultSpan0.Attributes?.ContainsKey("error.message"));
             Assert.Equal(ErrorMessage, resultSpan1.Attributes?["error.message"]);
-            Assert.False(resultSpan2.Attributes?.ContainsKey("error"));
-            Assert.False(resultSpan3.Attributes?.ContainsKey("error"));
+            Assert.False(resultSpan2.Attributes?.ContainsKey("error.message"));
+            Assert.False(resultSpan3.Attributes?.ContainsKey("error.message"));
         }
 
         [Fact]

--- a/tests/NewRelic.Telemetry.Tests/SpanBatchJsonTests.cs
+++ b/tests/NewRelic.Telemetry.Tests/SpanBatchJsonTests.cs
@@ -48,7 +48,6 @@ namespace NewRelic.Telemetry.Tests
                             { NewRelicConsts.Tracing.AttribNameDurationMs, 67 },
                             { NewRelicConsts.Tracing.AttribNameServiceName, "serviceName" },
                             { NewRelicConsts.Tracing.AttribNameName, "name" },
-                            { NewRelicConsts.Tracing.AttribNameHasError, true },
                         }),
                 });
 
@@ -83,8 +82,7 @@ namespace NewRelic.Telemetry.Tests
             TestHelpers.AssertForAttribValue(resultSpanAttribs, "name", "name");
             TestHelpers.AssertForAttribValue(resultSpanAttribs, "service.name", "serviceName");
             TestHelpers.AssertForAttribValue(resultSpanAttribs, "parent.id", "parentId");
-            TestHelpers.AssertForAttribValue(resultSpanAttribs, "error", true);
-            TestHelpers.AssertForAttribCount(resultSpanAttribs, 5);
+            TestHelpers.AssertForAttribCount(resultSpanAttribs, 4);
         }
 
         [Fact]
@@ -112,7 +110,6 @@ namespace NewRelic.Telemetry.Tests
                             { NewRelicConsts.Tracing.AttribNameDurationMs, 100 },
                             { NewRelicConsts.Tracing.AttribNameServiceName, "serviceName1" },
                             { NewRelicConsts.Tracing.AttribNameName, "name1" },
-                            { NewRelicConsts.Tracing.AttribNameHasError, true },
                         }),
                     new NewRelicSpan(
                         spanId: "span2",
@@ -166,9 +163,8 @@ namespace NewRelic.Telemetry.Tests
             TestHelpers.AssertForAttribValue(firstSpanAttribs, "name", "name1");
             TestHelpers.AssertForAttribValue(firstSpanAttribs, "service.name", "serviceName1");
             TestHelpers.AssertForAttribValue(firstSpanAttribs, "parent.id", "parentId1");
-            TestHelpers.AssertForAttribValue(firstSpanAttribs, "error", true);
 
-            TestHelpers.AssertForAttribCount(firstSpanAttribs, 5);
+            TestHelpers.AssertForAttribCount(firstSpanAttribs, 4);
 
             var secondSpan = resultSpans[1];
 
@@ -212,7 +208,6 @@ namespace NewRelic.Telemetry.Tests
                             { NewRelicConsts.Tracing.AttribNameDurationMs, 67 },
                             { NewRelicConsts.Tracing.AttribNameServiceName, "serviceName" },
                             { NewRelicConsts.Tracing.AttribNameName, "name" },
-                            { NewRelicConsts.Tracing.AttribNameHasError, true },
                         }),
                 });
 
@@ -255,8 +250,7 @@ namespace NewRelic.Telemetry.Tests
             TestHelpers.AssertForAttribValue(resultSpanAttribs, "name", "name");
             TestHelpers.AssertForAttribValue(resultSpanAttribs, "service.name", "serviceName");
             TestHelpers.AssertForAttribValue(resultSpanAttribs, "parent.id", "parentId");
-            TestHelpers.AssertForAttribValue(resultSpanAttribs, "error", true);
-            TestHelpers.AssertForAttribCount(resultSpanAttribs, 5);
+            TestHelpers.AssertForAttribCount(resultSpanAttribs, 4);
         }
     }
 }

--- a/tests/NewRelic.Telemetry.Tests/SpanBuilderTests.cs
+++ b/tests/NewRelic.Telemetry.Tests/SpanBuilderTests.cs
@@ -23,7 +23,6 @@ namespace NewRelic.Telemetry.Tests
                     { "adsfasdf", 12 },
                     { NewRelicConsts.Tracing.AttribNameDurationMs, 67 },
                     { NewRelicConsts.Tracing.AttribNameServiceName, "serviceName" },
-                    { NewRelicConsts.Tracing.AttribNameHasError, true },
                     { NewRelicConsts.Tracing.AttribNameName, "name" },
                 });
 
@@ -31,7 +30,6 @@ namespace NewRelic.Telemetry.Tests
             Assert.Equal("traceId", span.TraceId);
             Assert.Equal(1L, span.Timestamp);
             Assert.Equal("serviceName", span.Attributes?["service.name"]);
-            Assert.Equal(true, span.Attributes?["error"]);
             Assert.Equal(67, span.Attributes?["duration.ms"]);
             Assert.Equal("name", span.Attributes?["name"]);
             Assert.Equal("parentId", span.Attributes?["parent.id"]);


### PR DESCRIPTION
The New Relic UI does not rely on the `error` attribute. Currently, it only relies on the presence of the `error.message` attribute to indicate that a span has an error.