### PR TITLE
Only set error.message when span.Status == StatusCode.Error

### DIFF
--- a/src/NewRelic.OpenTelemetry/NewRelicTraceExporter.cs
+++ b/src/NewRelic.OpenTelemetry/NewRelicTraceExporter.cs
@@ -165,11 +165,15 @@ namespace NewRelic.OpenTelemetry
             }
 
             var status = openTelemetrySpan.GetStatus();
-            if (!status.IsOk)
+            if (status.StatusCode == StatusCode.Error)
             {
                 if (!string.IsNullOrWhiteSpace(status.Description))
                 {
                     newRelicSpanAttribs.Add(NewRelicConsts.Tracing.AttribNameErrorMsg, status.Description);
+                }
+                else
+                {
+                    newRelicSpanAttribs.Add(NewRelicConsts.Tracing.AttribNameErrorMsg, "Unspecified error");
                 }
             }
 

--- a/tests/NewRelic.OpenTelemetry.Tests/SpanConverterTests.cs
+++ b/tests/NewRelic.OpenTelemetry.Tests/SpanConverterTests.cs
@@ -43,7 +43,7 @@ namespace NewRelic.OpenTelemetry.Tests
         private static DateTimeOffset _traceStartTime = DateTime.UtcNow;
         private readonly (int? Parent, string Name, DateTimeOffset Start, DateTimeOffset End, Status Status, bool IsCallToNewRelic)[] _spanDefinitions = new (int?, string, DateTimeOffset, DateTimeOffset, Status, bool)[]
         {
-            (null, "Test Span 1", _traceStartTime, _traceStartTime.AddMilliseconds(225), Status.Ok, false),
+            (null, "Test Span 1", _traceStartTime, _traceStartTime.AddMilliseconds(225), Status.Unset, false),
             (0, "Test Span 2", _traceStartTime.AddMilliseconds(1), _traceStartTime.AddMilliseconds(100), Status.Error.WithDescription(ErrorMessage), false),
             (null, "Test Span 3", _traceStartTime.AddMilliseconds(2), _traceStartTime.AddMilliseconds(375), Status.Ok, false),
             (null, "Test Span 4", _traceStartTime.AddMilliseconds(3), _traceStartTime.AddMilliseconds(650), Status.Ok, false),


### PR DESCRIPTION
The OpenTelemetry spec changed in regards to span status. Only three possible values for status: `Unset` (default), `Ok`, and `Error`. See: https://github.com/open-telemetry/opentelemetry-specification/blob/5c9143b031c078543c400412ab214c37cb9903ea/specification/trace/api.md#set-status.

From the spec:

> Generally, Instrumentation Libraries SHOULD NOT set the status code to Ok, unless explicitly configured to do so. Instrumention libraries SHOULD leave the status code as Unset unless there is an error, as described above.

This PR fixes an issue where spans with the status `Unset` would be rendered as an error in the New Relic UI.

This issue was originally reported by @twaremike https://github.com/newrelic/newrelic-telemetry-sdk-dotnet/issues/140#issuecomment-713178515