### PR TITLE
Remove InstrumentationProvider config setting

### DIFF
--- a/src/NewRelic.OpenTelemetry/NewRelicExporterOptions.cs
+++ b/src/NewRelic.OpenTelemetry/NewRelicExporterOptions.cs
@@ -50,15 +50,6 @@ namespace NewRelic.OpenTelemetry
             set => TelemetryConfiguration.ServiceName = value;
         }
 
-        /// <summary>
-        /// Identifies the source of information that is being sent to New Relic.
-        /// </summary>
-        public string? InstrumentationProvider
-        {
-            get => TelemetryConfiguration.InstrumentationProvider;
-            set => TelemetryConfiguration.InstrumentationProvider = value;
-        }
-
         internal TelemetryConfiguration TelemetryConfiguration { get; } = new TelemetryConfiguration();
 
         /// <summary>

--- a/tests/NewRelic.OpenTelemetry.Tests/SpanConverterTests.cs
+++ b/tests/NewRelic.OpenTelemetry.Tests/SpanConverterTests.cs
@@ -200,7 +200,7 @@ namespace NewRelic.OpenTelemetry.Tests
             Assert.Equal(_otSpans.Count, _resultNRSpans.Count);
             Assert.NotNull(_resultNRSpanBatch?.CommonProperties.Attributes);
             Assert.True(_resultNRSpanBatch?.CommonProperties.Attributes.ContainsKey("instrumentation.provider"));
-            Assert.Equal(_options.InstrumentationProvider, _resultNRSpanBatch?.CommonProperties.Attributes["instrumentation.provider"]);
+            Assert.Equal("opentelemetry", _resultNRSpanBatch?.CommonProperties.Attributes["instrumentation.provider"]);
         }
     }
 }


### PR DESCRIPTION
For the exporter the InstrumentationProvider is always equal to `opentelemetry`.