### PR TITLE
Add collector.name to each span batch

### DIFF
--- a/src/NewRelic.OpenTelemetry/NewRelicExporterOptions.cs
+++ b/src/NewRelic.OpenTelemetry/NewRelicExporterOptions.cs
@@ -50,15 +50,6 @@ namespace NewRelic.OpenTelemetry
             set => TelemetryConfiguration.ServiceName = value;
         }
 
-        /// <summary>
-        /// Identifies the source of information that is being sent to New Relic.
-        /// </summary>
-        public string? InstrumentationProvider
-        {
-            get => TelemetryConfiguration.InstrumentationProvider;
-            set => TelemetryConfiguration.InstrumentationProvider = value;
-        }
-
         internal TelemetryConfiguration TelemetryConfiguration { get; } = new TelemetryConfiguration();
 
         /// <summary>

--- a/src/NewRelic.OpenTelemetry/NewRelicTraceExporter.cs
+++ b/src/NewRelic.OpenTelemetry/NewRelicTraceExporter.cs
@@ -59,8 +59,6 @@ namespace NewRelic.OpenTelemetry
 
             _config = options.TelemetryConfiguration;
 
-            _config.InstrumentationProvider = "opentelemetry";
-
             if (loggerFactory != null)
             {
                 _logger = loggerFactory.CreateLogger("NewRelicTraceExporter");

--- a/src/NewRelic.OpenTelemetry/NewRelicTraceExporter.cs
+++ b/src/NewRelic.OpenTelemetry/NewRelicTraceExporter.cs
@@ -28,7 +28,8 @@ namespace NewRelic.OpenTelemetry
         private static readonly string _productVersion = Assembly.GetExecutingAssembly().GetCustomAttribute<PackageVersionAttribute>().PackageVersion;
         private static readonly NewRelicSpanBatchCommonProperties _commonProperties = new NewRelicSpanBatchCommonProperties(
             null,
-            new Dictionary<string, object> {
+            new Dictionary<string, object>
+            {
                 { NewRelicConsts.AttribNameCollectorName, "newrelic-opentelemetry-exporter" },
                 { NewRelicConsts.AttribNameInstrumentationProvider, "opentelemetry" },
             });

--- a/src/NewRelic.OpenTelemetry/NewRelicTraceExporter.cs
+++ b/src/NewRelic.OpenTelemetry/NewRelicTraceExporter.cs
@@ -26,6 +26,12 @@ namespace NewRelic.OpenTelemetry
 
         private static readonly ActivitySpanId EmptyActivitySpanId = ActivitySpanId.CreateFromBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, });
         private static readonly string _productVersion = Assembly.GetExecutingAssembly().GetCustomAttribute<PackageVersionAttribute>().PackageVersion;
+        private static readonly NewRelicSpanBatchCommonProperties _commonProperties = new NewRelicSpanBatchCommonProperties(
+            null,
+            new Dictionary<string, object> {
+                { NewRelicConsts.AttribNameCollectorName, "newrelic-opentelemetry-exporter" },
+                { NewRelicConsts.AttribNameInstrumentationProvider, "opentelemetry" },
+            });
 
         private readonly TraceDataSender _spanDataSender;
         private readonly ILogger? _logger;
@@ -78,8 +84,10 @@ namespace NewRelic.OpenTelemetry
                 return ExportResult.Success;
             }
 
+            var spanBatch = new NewRelicSpanBatch(nrSpans, _commonProperties);
+
             Response? response = null;
-            Task.Run(async () => response = await _spanDataSender.SendDataAsync(nrSpans)).GetAwaiter().GetResult();
+            Task.Run(async () => response = await _spanDataSender.SendDataAsync(spanBatch)).GetAwaiter().GetResult();
 
             switch (response?.ResponseStatus)
             {

--- a/src/NewRelic.Telemetry/ITelemetryDataType.cs
+++ b/src/NewRelic.Telemetry/ITelemetryDataType.cs
@@ -15,7 +15,5 @@ namespace NewRelic.Telemetry
         where T : ITelemetryDataType<T>
     {
         string ToJson();
-
-        void SetInstrumentationProvider(string instrumentationProvider);
     }
 }

--- a/src/NewRelic.Telemetry/Metrics/NewRelicMetricBatch.cs
+++ b/src/NewRelic.Telemetry/Metrics/NewRelicMetricBatch.cs
@@ -62,10 +62,5 @@ namespace NewRelic.Telemetry.Metrics
             return JsonSerializer.Serialize(new[] { this }, JsonSerializerOptions);
 #endif
         }
-
-        public void SetInstrumentationProvider(string instrumentationProvider)
-        {
-            CommonProperties.SetInstrumentationProvider(instrumentationProvider);
-        }
     }
 }

--- a/src/NewRelic.Telemetry/Metrics/NewRelicMetricBatchCommonProperties.cs
+++ b/src/NewRelic.Telemetry/Metrics/NewRelicMetricBatchCommonProperties.cs
@@ -36,10 +36,5 @@ namespace NewRelic.Telemetry.Metrics
             IntervalMs = intervalMs;
             _attributes = attributes ?? new Dictionary<string, object>();
         }
-
-        public void SetInstrumentationProvider(string instrumentationProvider)
-        {
-            _attributes[NewRelicConsts.AttribNameInstrumentationProvider] = instrumentationProvider;
-        }
     }
 }

--- a/src/NewRelic.Telemetry/NewRelicConsts.cs
+++ b/src/NewRelic.Telemetry/NewRelicConsts.cs
@@ -10,6 +10,7 @@ namespace NewRelic.Telemetry
 #endif
     static class NewRelicConsts
     {
+        public const string AttribNameCollectorName = "collector.name";
         public const string AttribNameInstrumentationProvider = "instrumentation.provider";
 
         public static class Tracing

--- a/src/NewRelic.Telemetry/Spans/NewRelicSpanBatch.cs
+++ b/src/NewRelic.Telemetry/Spans/NewRelicSpanBatch.cs
@@ -62,10 +62,5 @@ namespace NewRelic.Telemetry.Tracing
             return JsonSerializer.Serialize(new[] { this }, JsonSerializerOptions);
 #endif
         }
-
-        public void SetInstrumentationProvider(string instrumentationProvider)
-        {
-            CommonProperties.SetInstrumentationProvider(instrumentationProvider);
-        }
     }
 }

--- a/src/NewRelic.Telemetry/Spans/NewRelicSpanBatchCommonProperties.cs
+++ b/src/NewRelic.Telemetry/Spans/NewRelicSpanBatchCommonProperties.cs
@@ -39,10 +39,5 @@ namespace NewRelic.Telemetry.Tracing
             TraceId = traceId;
             _attributes = attributes;
         }
-
-        public void SetInstrumentationProvider(string instrumentationProvider)
-        {
-            _attributes[NewRelicConsts.AttribNameInstrumentationProvider] = instrumentationProvider;
-        }
     }
 }

--- a/src/NewRelic.Telemetry/TelemetryConfiguration.cs
+++ b/src/NewRelic.Telemetry/TelemetryConfiguration.cs
@@ -78,11 +78,6 @@ namespace NewRelic.Telemetry
         public string? ServiceName { get; set; }
 
         /// <summary>
-        /// Identifies the source of information that is being sent to New Relic.
-        /// </summary>
-        public string? InstrumentationProvider { get; set; }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="TelemetryConfiguration"/> class.
         /// Creates the Configuration object accepting all default settings.
         /// </summary>

--- a/src/NewRelic.Telemetry/Transport/DataSender.cs
+++ b/src/NewRelic.Telemetry/Transport/DataSender.cs
@@ -108,11 +108,6 @@ namespace NewRelic.Telemetry.Transport
                 return Response.Failure("API Key was not available");
             }
 
-            if (_config.InstrumentationProvider != null)
-            {
-                dataToSend.SetInstrumentationProvider(_config.InstrumentationProvider);
-            }
-
             return await SendDataAsync(dataToSend, 0);
         }
 

--- a/tests/NewRelic.OpenTelemetry.Tests/SpanConverterTests.cs
+++ b/tests/NewRelic.OpenTelemetry.Tests/SpanConverterTests.cs
@@ -200,7 +200,7 @@ namespace NewRelic.OpenTelemetry.Tests
             Assert.Equal(_otSpans.Count, _resultNRSpans.Count);
             Assert.NotNull(_resultNRSpanBatch?.CommonProperties.Attributes);
             Assert.True(_resultNRSpanBatch?.CommonProperties.Attributes.ContainsKey("instrumentation.provider"));
-            Assert.Equal(_options.InstrumentationProvider, _resultNRSpanBatch?.CommonProperties.Attributes["instrumentation.provider"]);
+            Assert.Equal("opentelemetry", _resultNRSpanBatch?.CommonProperties.Attributes["instrumentation.provider"]);
         }
     }
 }

--- a/tests/NewRelic.OpenTelemetry.Tests/SpanConverterTests.cs
+++ b/tests/NewRelic.OpenTelemetry.Tests/SpanConverterTests.cs
@@ -195,11 +195,11 @@ namespace NewRelic.OpenTelemetry.Tests
         }
 
         [Fact]
-        public void Test_InstrumentationProvider()
+        public void Test_CommonProperties()
         {
             Assert.Equal(_otSpans.Count, _resultNRSpans.Count);
             Assert.NotNull(_resultNRSpanBatch?.CommonProperties.Attributes);
-            Assert.True(_resultNRSpanBatch?.CommonProperties.Attributes.ContainsKey("instrumentation.provider"));
+            Assert.Equal("newrelic-opentelemetry-exporter", _resultNRSpanBatch?.CommonProperties.Attributes["collector.name"]);
             Assert.Equal("opentelemetry", _resultNRSpanBatch?.CommonProperties.Attributes["instrumentation.provider"]);
         }
     }

--- a/tests/NewRelic.Telemetry.Tests/SpanDataSenderTests.cs
+++ b/tests/NewRelic.Telemetry.Tests/SpanDataSenderTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using NewRelic.Telemetry.Tracing;
@@ -65,52 +64,6 @@ namespace NewRelic.Telemetry.Tests
             var response = dataSender.SendDataAsync(spanBatch).Result;
 
             Assert.Equal(NewRelicResponseStatus.Success, response.ResponseStatus);
-        }
-
-        [Fact]
-        public void InstrumentationProviderSuppliedWhenConfigured()
-        {
-            const string traceId = "123";
-            const string instrumentationProvider = "TestInstrumentationProvider";
-
-            var span = new NewRelicSpan(
-                            traceId: null,
-                            spanId: "Span1",
-                            timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                            parentSpanId: null,
-                            attributes: new Dictionary<string, object>()
-                            {
-                                { NewRelicConsts.Tracing.AttribNameName, "TestSpan" },
-                            });
-
-            var spanBatch = new NewRelicSpanBatch(
-                    spans: new[] { span },
-                    commonProperties: new NewRelicSpanBatchCommonProperties(traceId));
-
-            var dataSender = new TraceDataSender(
-                new TelemetryConfiguration()
-                {
-                    ApiKey = "123456",
-                    InstrumentationProvider = instrumentationProvider,
-                }, null);
-
-            NewRelicSpanBatch? capturedSpanbatch = null;
-
-            dataSender.WithCaptureSendDataAsyncDelegate((spanBatch, attempt) =>
-            {
-                capturedSpanbatch = spanBatch;
-            });
-
-            var response = dataSender.SendDataAsync(spanBatch).Result;
-
-            Assert.NotNull(capturedSpanbatch);
-
-            var actualSpans = spanBatch.Spans.ToArray();
-
-            Assert.Single(actualSpans);
-            Assert.NotNull(spanBatch.CommonProperties.Attributes);
-            Assert.True(spanBatch.CommonProperties.Attributes.ContainsKey("instrumentation.provider"));
-            Assert.Equal(instrumentationProvider, spanBatch.CommonProperties.Attributes["instrumentation.provider"]);
         }
     }
 }


### PR DESCRIPTION
Removes InstrumentationProvider from TelemetryConfiguration since this is no longer part of the spec.

However, both `collector.name` and `instrumentation.provider` are expected to be on each batch of spans sent by the exporter. See https://github.com/newrelic/newrelic-exporter-specs/blob/61ebffa7d292c2085af612706f11d5b0a5108da9/opentelemetry/OpenTelemetry-Spans.md