### PR TITLE
Remove sleep from console sample app

### DIFF
--- a/examples/NewRelic.OpenTelemetry/ConsoleCore/NewRelic.Examples.ConsoleCore.csproj
+++ b/examples/NewRelic.OpenTelemetry/ConsoleCore/NewRelic.Examples.ConsoleCore.csproj
@@ -6,6 +6,19 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="appsettings.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="0.7.0-beta.1" />
   </ItemGroup>

--- a/examples/NewRelic.OpenTelemetry/ConsoleCore/Program.cs
+++ b/examples/NewRelic.OpenTelemetry/ConsoleCore/Program.cs
@@ -57,18 +57,14 @@ namespace SampleConsoleCoreApp
             {
                 using (var activity = SampleActivitySource.StartActivity("SampleConsoleCoreAppSpan"))
                 {
-                    //Console.WriteLine("Creating root of trace.");
-
                     var message = "Hello, OpenTelemetry with New Relic!";
                     activity?.SetTag("aNumber", 42);
                     activity?.SetTag("message", message);
 
-                    //Console.WriteLine("\nMaking an external HTTP request which will be added as a child span of the trace.");
-
                     var httpClient = new HttpClient();
-                    var request = httpClient.GetAsync("https://www.newrelic.com");
+                    httpClient.GetAsync("https://www.newrelic.com");
 
-                    //Console.WriteLine($"Web request result: {request.Result.StatusCode}");
+                    System.Threading.Thread.Sleep(1000);
                 }
             }
         }

--- a/examples/NewRelic.OpenTelemetry/ConsoleCore/Program.cs
+++ b/examples/NewRelic.OpenTelemetry/ConsoleCore/Program.cs
@@ -12,12 +12,19 @@ namespace SampleConsoleCoreApp
         private const string ActivitySourceName = "NewRelic.OpenTelemetryExporter.SampleConsoleCoreApp";
         private static readonly ActivitySource SampleActivitySource = new ActivitySource(ActivitySourceName);
 
-        // Set these values for yourself
-        private const string MyNewRelicInsightsInsertApiKey = "<YOUR_NR_INSIGHTS_INSERT_API_KEY_HERE>";
-        private const string MyServiceName = "SampleConsoleCoreApp";
+        // Set these values by environment variable
+        private static readonly string MyNewRelicInsightsInsertApiKey = Environment.GetEnvironmentVariable("NR_API_KEY");
+        private static readonly string MyServiceName = Environment.GetEnvironmentVariable("NR_SAMPLE_APP_NAME") ?? "SampleConsoleCoreApp";
 
         static void Main(string[] args)
         {
+
+            if (MyNewRelicInsightsInsertApiKey == null)
+            {
+                Console.WriteLine("Please provide your New Relic Insights Insert API key by setting the 'NR_API_KEY' environment variable.");
+                return;
+            }
+
             var loggerFactory = LoggerFactory.Create(builder =>
                 {
                     builder.SetMinimumLevel(LogLevel.Debug)

--- a/examples/NewRelic.OpenTelemetry/ConsoleCore/Program.cs
+++ b/examples/NewRelic.OpenTelemetry/ConsoleCore/Program.cs
@@ -52,8 +52,7 @@ namespace SampleConsoleCoreApp
                 Console.WriteLine($"Web request result: {request.Result.StatusCode}");
             }
 
-            Console.WriteLine("\nTrace finished, waiting ten seconds to allow trace to be collected and sent to New Relic.");
-            System.Threading.Thread.Sleep(10000);
+            Console.WriteLine("\nFinished.");
         }
     }
 }

--- a/examples/NewRelic.OpenTelemetry/ConsoleCore/Program.cs
+++ b/examples/NewRelic.OpenTelemetry/ConsoleCore/Program.cs
@@ -32,7 +32,7 @@ namespace SampleConsoleCoreApp
                 }
             );
 
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .AddNewRelicExporter(options =>
                 {
@@ -41,22 +41,23 @@ namespace SampleConsoleCoreApp
                     options.AuditLoggingEnabled = true;
                 }, loggerFactory)
                 .AddHttpClientInstrumentation()
-                .Build();
-
-            using (var activity = SampleActivitySource.StartActivity("SampleConsoleCoreAppSpan"))
+                .Build())
             {
-                Console.WriteLine("Creating root of trace.");
+                using (var activity = SampleActivitySource.StartActivity("SampleConsoleCoreAppSpan"))
+                {
+                    Console.WriteLine("Creating root of trace.");
 
-                var message = "Hello, OpenTelemetry with New Relic!";
-                activity?.SetTag("aNumber", 42);
-                activity?.SetTag("message", message);
+                    var message = "Hello, OpenTelemetry with New Relic!";
+                    activity?.SetTag("aNumber", 42);
+                    activity?.SetTag("message", message);
 
-                Console.WriteLine("\nMaking an external HTTP request which will be added as a child span of the trace.");
+                    Console.WriteLine("\nMaking an external HTTP request which will be added as a child span of the trace.");
 
-                var httpClient = new HttpClient();
-                var request = httpClient.GetAsync("https://www.newrelic.com");
+                    var httpClient = new HttpClient();
+                    var request = httpClient.GetAsync("https://www.newrelic.com");
 
-                Console.WriteLine($"Web request result: {request.Result.StatusCode}");
+                    Console.WriteLine($"Web request result: {request.Result.StatusCode}");
+                }
             }
 
             Console.WriteLine("\nFinished.");

--- a/examples/NewRelic.OpenTelemetry/ConsoleCore/appsettings.json
+++ b/examples/NewRelic.OpenTelemetry/ConsoleCore/appsettings.json
@@ -1,0 +1,6 @@
+{
+	"NewRelic": {
+		"ApiKey": "YOUR NEW RELIC INSIGHTS INSERT API KEY GOES HERE",
+		"ServiceName": "SampleConsoleCoreApp"
+	}
+}


### PR DESCRIPTION
Responding to feedback from @twaremike in issue #140.  The arbitrary ten second sleep is not necessary.  The spans get exported when the exporter is shut down upon disposal, i.e. when the console app exits.

There is still an issue with the debug logging that prints out - depending on what shell you're running the program from, the output may or may not be completely displayed (for example, `git bash` always displays all of the debug logging, but it gets cut off in Cmd.exe and powershell (5.1, haven't tried powershell core (6.0+) yet)).  This is why I put the sleep in place in the first place, I wanted to make sure the debug output would be displayed.
(Update: the last commit makes this somewhat better by putting the tracing activity in a `using` scope which will trigger the disposal, and therefore export, before the program exits.)

I did spend some time going down the path of trying to implement a manual flush.  I came up with something like:

```
var config = new NewRelicExporterOptions();
/// set config options
var exporter = new NewRelicTraceExporter(config, loggerFactory);
using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                .AddProcessor(new BatchExportProcessor<Activity>(exporter)
/// etc
```

So that I would have a reference to the exporter and could try to call `.Export()` manually before exiting the program.  However, `.Export()` takes arguments of a data type I couldn't figure out how to get from anywhere.  I did figure out that calling `.Shutdown()` on the exporter would force the export.  However, all of this felt pretty non-canonical compared to the `.AddNewRelicExporter()` extension method, so I abandoned this approach.  It was still useful to get more of a sense of what is going on under the covers.

I also added a way to supply the configurable options (API key and app name) via environment variables.