### PR TITLE
adds workflow for checking stale PRs and Issues

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -1,0 +1,17 @@
+name: "Close stale Issues"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This Issue has been marked stale after 90 days with no activity. It will be closed in 30 days if there is no activity.'
+        days-before-stale: 90
+        days-before-close: 30
+        stale-issue-label: 'stale'
+        exempt-issue-labels: 'good first issue,help wanted,in progress,on hold,in review,roadmap'

--- a/.github/workflows/stale_pr.yml
+++ b/.github/workflows/stale_pr.yml
@@ -1,0 +1,17 @@
+name: "Close stale PRs"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: 'This PR has been marked stale after 30 days with no activity. It will be closed in 5 days if there is no activity.'
+        days-before-stale: 30
+        days-before-close: 5
+        stale-pr-label: 'stale'
+        exempt-pr-labels: 'on hold,in review'


### PR DESCRIPTION
Issues will be marked `stale` after 90 days, removed after 30 more days unless updated.
PRs will be marke `stale` after 30 days, removed after 5 more days unless updated.