### PR TITLE
Update build flags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
       shell: powershell
 
     - name: Build
-      run:  dotnet build ${{ env.solution_file_path }} --configuration Release
+      run:  dotnet build ${{ env.solution_file_path }} --configuration Release --no-restore -p:Deterministic=true
       shell: powershell
 
     - name: Unit Tests - TelemetrySDK

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -33,4 +33,12 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(Deterministic)'=='true'">
+    <SourceRoot Include="$(MSBuildThisFileDirectory)/" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(Deterministic)'=='true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Updates the build flags and build commands so that we can generate Nuget packages that pass the Nuget Package Explorer health checks. 

This also keeps our build flags in line with the build flags used for the OpenTelemetry SDK that we depend on.

This does not change the behavior for the packages in MyGet. The packages pushed to MyGet will no longer pass the health checks.

See https://github.com/dotnet/sourcelink/blob/master/docs/README.md#deterministicsourcepaths for more information about the build flags that are being used.