### PR TITLE
Reduce test flicker

### DIFF
--- a/tests/NewRelic.Telemetry.Tests/DataSenderTests.cs
+++ b/tests/NewRelic.Telemetry.Tests/DataSenderTests.cs
@@ -425,7 +425,7 @@ namespace NewRelic.Telemetry.Tests
             const int delayMs = 10000;
 
             // The actual retry delay will be slightly less than delayMs since UtcNow is recalculated in RetryWithServerDelay()
-            var errorMargin = TimeSpan.FromMilliseconds(50).TotalMilliseconds;
+            var errorMargin = TimeSpan.FromMilliseconds(1000).TotalMilliseconds;
             var actualResponseFromTestRun = new List<Response>();
 
             uint actualDelayFromTestRun = 0;


### PR DESCRIPTION
Increases the error margin in the flickering test.

We should eventually replace this test with more of an end to end test where we actually verify that the retry occurred after waiting until the retry date.