### PR TITLE
Leverage OTel logging for the exporter

### DIFF
--- a/examples/NewRelic.OpenTelemetry/AspNetCore/Startup.cs
+++ b/examples/NewRelic.OpenTelemetry/AspNetCore/Startup.cs
@@ -36,7 +36,7 @@ namespace SampleAspNetCoreApp
                     .AddNewRelicExporter(options =>
                     {
                         options.ApiKey = this.Configuration.GetValue<string>("NewRelic:ApiKey");
-                    }, loggerFactory)
+                    })
                     .AddAspNetCoreInstrumentation()
                     .AddHttpClientInstrumentation();
             });

--- a/examples/NewRelic.OpenTelemetry/ConsoleCore/Program.cs
+++ b/examples/NewRelic.OpenTelemetry/ConsoleCore/Program.cs
@@ -40,7 +40,7 @@ namespace SampleConsoleCoreApp
                 {
                     options.ApiKey = nrApiKey;
                     options.AuditLoggingEnabled = true;
-                }, loggerFactory)
+                })
                 .AddHttpClientInstrumentation()
                 .Build())
             {

--- a/src/NewRelic.OpenTelemetry/Internal/NewRelicEventSource.cs
+++ b/src/NewRelic.OpenTelemetry/Internal/NewRelicEventSource.cs
@@ -1,0 +1,123 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Diagnostics.Tracing;
+
+namespace NewRelic.OpenTelemetry.Internal
+{
+    [EventSource(Name = "OpenTelemetry-NewRelic")]
+    internal class NewRelicEventSource : EventSource
+    {
+        public static NewRelicEventSource Log = new NewRelicEventSource();
+
+        [NonEvent]
+        public void Debug(string message, Exception? exception = null)
+        {
+            if (IsEnabled(EventLevel.Informational, (EventKeywords)(-1)))
+            {
+                if (exception != null)
+                {
+                    EmitInformationalMessage(message, exception.ToString());
+                }
+                else
+                {
+                    EmitInformationalMessage(message);
+                }
+            }
+        }
+
+        [NonEvent]
+        public void Error(string message, Exception? exception = null)
+        {
+            if (IsEnabled(EventLevel.Error, (EventKeywords)(-1)))
+            {
+                if (exception != null)
+                {
+                    EmitErrorMessage(message, exception.ToString());
+                }
+                else
+                {
+                    EmitErrorMessage(message);
+                }
+            }
+        }
+
+        [NonEvent]
+        public void Exception(Exception exception)
+        {
+            if (IsEnabled(EventLevel.Error, (EventKeywords)(-1)))
+            {
+                EmitErrorMessage(exception.ToString());
+            }
+        }
+
+        [NonEvent]
+        public void Info(string message, Exception? exception = null)
+        {
+            if (IsEnabled(EventLevel.Informational, (EventKeywords)(-1)))
+            {
+                if (exception != null)
+                {
+                    EmitInformationalMessage(message, exception.ToString());
+                }
+                else
+                {
+                    EmitInformationalMessage(message);
+                }
+            }
+        }
+
+        [NonEvent]
+        public void Warning(string message, Exception? exception = null)
+        {
+            if (IsEnabled(EventLevel.Warning, (EventKeywords)(-1)))
+            {
+                if (exception != null)
+                {
+                    EmitWarningMessage(message, exception.ToString());
+                }
+                else
+                {
+                    EmitWarningMessage(message);
+                }
+            }
+        }
+
+        [Event(1, Message = "New Relic: '{0}'", Level = EventLevel.Warning)]
+        public void EmitWarningMessage(string message)
+        {
+            WriteEvent(1, message);
+        }
+
+        [Event(2, Message = "New Relic: '{0}': {1}", Level = EventLevel.Warning)]
+        public void EmitWarningMessage(string message, string error)
+        {
+            WriteEvent(1, message, error);
+        }
+
+        [Event(3, Message = "New Relic: '{0}'", Level = EventLevel.Informational)]
+        public void EmitInformationalMessage(string message)
+        {
+            WriteEvent(1, message);
+        }
+
+        [Event(4, Message = "New Relic: '{0}': {1}", Level = EventLevel.Informational)]
+        public void EmitInformationalMessage(string message, string error)
+        {
+            WriteEvent(1, message, error);
+        }
+
+        [Event(5, Message = "New Relic: '{0}'", Level = EventLevel.Error)]
+        public void EmitErrorMessage(string message)
+        {
+            WriteEvent(1, message);
+        }
+
+        [Event(6, Message = "New Relic: '{0}': {1}", Level = EventLevel.Error)]
+        public void EmitErrorMessage(string message, string error)
+        {
+            WriteEvent(1, message, error);
+        }
+    }
+}

--- a/src/NewRelic.OpenTelemetry/Internal/NewRelicEventSource.cs
+++ b/src/NewRelic.OpenTelemetry/Internal/NewRelicEventSource.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Diagnostics.Tracing;
+using System.Globalization;
+using System.Threading;
 
 namespace NewRelic.OpenTelemetry.Internal
 {
@@ -18,7 +20,7 @@ namespace NewRelic.OpenTelemetry.Internal
             {
                 if (exception != null)
                 {
-                    EmitInformationalMessage(message, exception.ToString());
+                    EmitInformationalMessage(message, ToInvariantString(exception));
                 }
                 else
                 {
@@ -34,7 +36,7 @@ namespace NewRelic.OpenTelemetry.Internal
             {
                 if (exception != null)
                 {
-                    EmitErrorMessage(message, exception.ToString());
+                    EmitErrorMessage(message, ToInvariantString(exception));
                 }
                 else
                 {
@@ -48,7 +50,7 @@ namespace NewRelic.OpenTelemetry.Internal
         {
             if (IsEnabled(EventLevel.Error, (EventKeywords)(-1)))
             {
-                EmitErrorMessage(exception.ToString());
+                EmitErrorMessage(ToInvariantString(exception));
             }
         }
 
@@ -59,7 +61,7 @@ namespace NewRelic.OpenTelemetry.Internal
             {
                 if (exception != null)
                 {
-                    EmitInformationalMessage(message, exception.ToString());
+                    EmitInformationalMessage(message, ToInvariantString(exception));
                 }
                 else
                 {
@@ -75,7 +77,7 @@ namespace NewRelic.OpenTelemetry.Internal
             {
                 if (exception != null)
                 {
-                    EmitWarningMessage(message, exception.ToString());
+                    EmitWarningMessage(message, ToInvariantString(exception));
                 }
                 else
                 {
@@ -118,6 +120,25 @@ namespace NewRelic.OpenTelemetry.Internal
         public void EmitErrorMessage(string message, string error)
         {
             WriteEvent(1, message, error);
+        }
+
+        // Formats the exception using the same logic that is used within the OTel SDK eventsource
+        // loggers so that the log messages can be normalized to use the same culture information
+        // as the rest of the log messages. For a more detailed explanation refer to the following link.
+        // https://github.com/open-telemetry/opentelemetry-dotnet/pull/944#discussion_r462467096
+        private static string ToInvariantString(Exception exception)
+        {
+            var originalUICulture = Thread.CurrentThread.CurrentUICulture;
+
+            try
+            {
+                Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+                return exception.ToString();
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentUICulture = originalUICulture;
+            }
         }
     }
 }

--- a/src/NewRelic.OpenTelemetry/Internal/NewRelicEventSource.cs
+++ b/src/NewRelic.OpenTelemetry/Internal/NewRelicEventSource.cs
@@ -20,7 +20,7 @@ namespace NewRelic.OpenTelemetry.Internal
             {
                 if (exception != null)
                 {
-                    EmitInformationalMessage(message, ToInvariantString(exception));
+                    EmitInformationalMessageWithError(message, ToInvariantString(exception));
                 }
                 else
                 {
@@ -36,7 +36,7 @@ namespace NewRelic.OpenTelemetry.Internal
             {
                 if (exception != null)
                 {
-                    EmitErrorMessage(message, ToInvariantString(exception));
+                    EmitErrorMessageWithError(message, ToInvariantString(exception));
                 }
                 else
                 {
@@ -61,7 +61,7 @@ namespace NewRelic.OpenTelemetry.Internal
             {
                 if (exception != null)
                 {
-                    EmitInformationalMessage(message, ToInvariantString(exception));
+                    EmitInformationalMessageWithError(message, ToInvariantString(exception));
                 }
                 else
                 {
@@ -77,7 +77,7 @@ namespace NewRelic.OpenTelemetry.Internal
             {
                 if (exception != null)
                 {
-                    EmitWarningMessage(message, ToInvariantString(exception));
+                    EmitWarningMessageWithError(message, ToInvariantString(exception));
                 }
                 else
                 {
@@ -93,33 +93,33 @@ namespace NewRelic.OpenTelemetry.Internal
         }
 
         [Event(2, Message = "New Relic: '{0}': {1}", Level = EventLevel.Warning)]
-        public void EmitWarningMessage(string message, string error)
+        public void EmitWarningMessageWithError(string message, string error)
         {
-            WriteEvent(1, message, error);
+            WriteEvent(2, message, error);
         }
 
         [Event(3, Message = "New Relic: '{0}'", Level = EventLevel.Informational)]
         public void EmitInformationalMessage(string message)
         {
-            WriteEvent(1, message);
+            WriteEvent(3, message);
         }
 
         [Event(4, Message = "New Relic: '{0}': {1}", Level = EventLevel.Informational)]
-        public void EmitInformationalMessage(string message, string error)
+        public void EmitInformationalMessageWithError(string message, string error)
         {
-            WriteEvent(1, message, error);
+            WriteEvent(4, message, error);
         }
 
         [Event(5, Message = "New Relic: '{0}'", Level = EventLevel.Error)]
         public void EmitErrorMessage(string message)
         {
-            WriteEvent(1, message);
+            WriteEvent(5, message);
         }
 
         [Event(6, Message = "New Relic: '{0}': {1}", Level = EventLevel.Error)]
-        public void EmitErrorMessage(string message, string error)
+        public void EmitErrorMessageWithError(string message, string error)
         {
-            WriteEvent(1, message, error);
+            WriteEvent(6, message, error);
         }
 
         // Formats the exception using the same logic that is used within the OTel SDK eventsource

--- a/src/NewRelic.OpenTelemetry/Internal/SelfDiagnosticsLogger.cs
+++ b/src/NewRelic.OpenTelemetry/Internal/SelfDiagnosticsLogger.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using NewRelic.Telemetry;
+
+namespace NewRelic.OpenTelemetry.Internal
+{
+    internal class SelfDiagnosticsLogger : ITelemetryLogger
+    {
+        public void Debug(string message, Exception? exception = null)
+        {
+            NewRelicEventSource.Log.Debug(message, exception);
+        }
+
+        public void Error(string message, Exception? exception = null)
+        {
+            NewRelicEventSource.Log.Error(message, exception);
+        }
+
+        public void Exception(Exception exception)
+        {
+            NewRelicEventSource.Log.Exception(exception);
+        }
+
+        public void Info(string message, Exception? exception = null)
+        {
+            NewRelicEventSource.Log.Info(message, exception);
+        }
+
+        public void Warning(string message, Exception? exception = null)
+        {
+            NewRelicEventSource.Log.Warning(message, exception);
+        }
+    }
+}

--- a/src/NewRelic.OpenTelemetry/NewRelic.OpenTelemetry.csproj
+++ b/src/NewRelic.OpenTelemetry/NewRelic.OpenTelemetry.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <Description>New Relic support for OpenTelemetry .NET</Description>
@@ -13,7 +13,7 @@
     <Compile Include="..\NewRelic.Telemetry\PackageVersionAttribute.cs" Link="NewRelic.Telemetry\PackageVersionAttribute.cs" />
     <Compile Include="..\NewRelic.Telemetry\ProductInfo.cs" Link="NewRelic.Telemetry\ProductInfo.cs" />
     <Compile Include="..\NewRelic.Telemetry\TelemetryConfiguration.cs" Link="NewRelic.Telemetry\TelemetryConfiguration.cs" />
-    <Compile Include="..\NewRelic.Telemetry\Logging\TelemetryLogging.cs" Link="NewRelic.Telemetry\Logging\TelemetryLogging.cs" />
+    <Compile Include="..\NewRelic.Telemetry\Logging\ITelemetryLogger.cs" Link="NewRelic.Telemetry\Logging\ITelemetryLogger.cs" />
     <Compile Include="..\NewRelic.Telemetry\Spans\NewRelicSpan.cs" Link="NewRelic.Telemetry\Spans\NewRelicSpan.cs" />
     <Compile Include="..\NewRelic.Telemetry\Spans\NewRelicSpanBatch.cs" Link="NewRelic.Telemetry\Spans\NewRelicSpanBatch.cs" />
     <Compile Include="..\NewRelic.Telemetry\Spans\NewRelicSpanBatchCommonProperties.cs" Link="NewRelic.Telemetry\Spans\NewRelicSpanBatchCommonProperties.cs" />
@@ -27,12 +27,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
     <PackageReference Include="System.Text.Json" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/NewRelic.OpenTelemetry/NewRelicExporterHelperExtensions.cs
+++ b/src/NewRelic.OpenTelemetry/NewRelicExporterHelperExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using Microsoft.Extensions.Logging;
 using NewRelic.OpenTelemetry;
 
 namespace OpenTelemetry.Trace
@@ -17,21 +16,9 @@ namespace OpenTelemetry.Trace
         /// Adds New Relic exporter to the TracerProvider.
         /// </summary>
         /// <param name="builder"><see cref="TracerProviderBuilder"/> builder to use.</param>
-        /// <param name="options">Exporter configuration options.</param>
+        /// <param name="configure">A method to configure the exporter options.</param>
         /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
-        public static TracerProviderBuilder AddNewRelicExporter(this TracerProviderBuilder builder, Action<NewRelicExporterOptions> options)
-        {
-            return AddNewRelicExporter(builder, options, null!);
-        }
-
-        /// <summary>
-        /// Adds New Relic exporter to the TracerProvider and enables the exporter to log to an ILogger.
-        /// </summary>
-        /// <param name="builder"><see cref="TracerProviderBuilder"/> builder to use.</param>
-        /// <param name="configure">Exporter configuration options.</param>
-        /// <param name="loggerFactory">ILoggerFactory instance for creating an ILogger.</param>
-        /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
-        public static TracerProviderBuilder AddNewRelicExporter(this TracerProviderBuilder builder, Action<NewRelicExporterOptions> configure, ILoggerFactory loggerFactory)
+        public static TracerProviderBuilder AddNewRelicExporter(this TracerProviderBuilder builder, Action<NewRelicExporterOptions> configure)
         {
             if (builder == null)
             {
@@ -40,7 +27,7 @@ namespace OpenTelemetry.Trace
 
             var options = new NewRelicExporterOptions();
             configure?.Invoke(options);
-            var exporter = new NewRelicTraceExporter(options, loggerFactory);
+            var exporter = new NewRelicTraceExporter(options);
 
             if (options.ExportProcessorType == ExportProcessorType.Simple)
             {

--- a/src/NewRelic.Telemetry/Logging/ITelemetryLogger.cs
+++ b/src/NewRelic.Telemetry/Logging/ITelemetryLogger.cs
@@ -1,0 +1,25 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+
+namespace NewRelic.Telemetry
+{
+#if INTERNALIZE_TELEMETRY_SDK
+    internal
+#else
+    public
+#endif
+    interface ITelemetryLogger
+    {
+        void Debug(string message, Exception? exception = null);
+
+        void Error(string message, Exception? exception = null);
+
+        void Exception(Exception exception);
+
+        void Info(string message, Exception? exception = null);
+
+        void Warning(string message, Exception? exception = null);
+    }
+}

--- a/src/NewRelic.Telemetry/Logging/ITelemetryLogger.cs
+++ b/src/NewRelic.Telemetry/Logging/ITelemetryLogger.cs
@@ -5,12 +5,7 @@ using System;
 
 namespace NewRelic.Telemetry
 {
-#if INTERNALIZE_TELEMETRY_SDK
-    internal
-#else
-    public
-#endif
-    interface ITelemetryLogger
+    internal interface ITelemetryLogger
     {
         void Debug(string message, Exception? exception = null);
 

--- a/src/NewRelic.Telemetry/Logging/TelemetryLogging.cs
+++ b/src/NewRelic.Telemetry/Logging/TelemetryLogging.cs
@@ -15,7 +15,7 @@ namespace NewRelic.Telemetry
 #else
     public
 #endif
-    class TelemetryLogging
+    class TelemetryLogging : ITelemetryLogger
     {
         private const string Prefix = "NewRelic Telemetry:";
         private const string Category = "NewRelic.Telemetry";
@@ -27,32 +27,32 @@ namespace NewRelic.Telemetry
             return $"{Prefix} {state} {error}".Trim();
         }
 
-        internal TelemetryLogging(ILoggerFactory? loggerFactory)
+        public TelemetryLogging(ILoggerFactory? loggerFactory)
         {
             _logger = loggerFactory?.CreateLogger(Category) ?? NullLogger.Instance;
         }
 
-        internal void Debug(string message, Exception? exception = null)
+        public void Debug(string message, Exception? exception = null)
         {
             _logger.Log(LogLevel.Debug, 0, message, exception, MessageFormatter);
         }
 
-        internal void Error(string message, Exception? exception = null)
+        public void Error(string message, Exception? exception = null)
         {
             _logger.Log(LogLevel.Error, 0, message, exception, MessageFormatter);
         }
 
-        internal void Exception(Exception ex)
+        public void Exception(Exception exception)
         {
-            _logger.Log(LogLevel.Error, 0, ex.GetType().Name, ex, MessageFormatter);
+            _logger.Log(LogLevel.Error, 0, exception.GetType().Name, exception, MessageFormatter);
         }
 
-        internal void Info(string message, Exception? exception = null)
+        public void Info(string message, Exception? exception = null)
         {
             _logger.Log(LogLevel.Information, 0, message, exception, MessageFormatter);
         }
 
-        internal void Warning(string message, Exception? exception = null)
+        public void Warning(string message, Exception? exception = null)
         {
             _logger.Log(LogLevel.Warning, 0, message, exception, MessageFormatter);
         }

--- a/src/NewRelic.Telemetry/Logging/TelemetryLogging.cs
+++ b/src/NewRelic.Telemetry/Logging/TelemetryLogging.cs
@@ -10,12 +10,7 @@ namespace NewRelic.Telemetry
     /// <summary>
     /// Manages logging within the Telemetry SDK.
     /// </summary>
-#if INTERNALIZE_TELEMETRY_SDK
-    internal
-#else
-    public
-#endif
-    class TelemetryLogging : ITelemetryLogger
+    internal class TelemetryLogging : ITelemetryLogger
     {
         private const string Prefix = "NewRelic Telemetry:";
         private const string Category = "NewRelic.Telemetry";

--- a/src/NewRelic.Telemetry/Metrics/MetricDataSender.cs
+++ b/src/NewRelic.Telemetry/Metrics/MetricDataSender.cs
@@ -26,7 +26,7 @@ namespace NewRelic.Telemetry.Metrics
         /// </summary>
         /// <param name="configOptions"></param>
         public MetricDataSender(TelemetryConfiguration configOptions)
-            : base(configOptions)
+            : base(configOptions, null)
         {
         }
 

--- a/src/NewRelic.Telemetry/Spans/TraceDataSender.cs
+++ b/src/NewRelic.Telemetry/Spans/TraceDataSender.cs
@@ -7,8 +7,8 @@ using System.Linq;
 using System.Threading.Tasks;
 #if !INTERNALIZE_TELEMETRY_SDK
 using Microsoft.Extensions.Configuration;
-#endif
 using Microsoft.Extensions.Logging;
+#endif
 using NewRelic.Telemetry.Transport;
 
 namespace NewRelic.Telemetry.Tracing
@@ -50,20 +50,20 @@ namespace NewRelic.Telemetry.Tracing
             return result;
         }
 
+#if !INTERNALIZE_TELEMETRY_SDK
         public TraceDataSender(TelemetryConfiguration config, ILoggerFactory? loggerFactory)
             : base(config, loggerFactory)
         {
         }
 
-#if !INTERNALIZE_TELEMETRY_SDK
         public TraceDataSender(IConfiguration config, ILoggerFactory? loggerFactory)
             : base(config, loggerFactory)
         {
         }
 #endif
 
-        internal TraceDataSender(TelemetryConfiguration config, ILoggerFactory? loggerFactory, string telemetrySdkVersionOverride)
-            : base(config, loggerFactory, telemetrySdkVersionOverride)
+        internal TraceDataSender(TelemetryConfiguration config, ITelemetryLogger logger, string telemetrySdkVersionOverride)
+            : base(config, logger, telemetrySdkVersionOverride)
         {
         }
 

--- a/src/NewRelic.Telemetry/Transport/DataSender.cs
+++ b/src/NewRelic.Telemetry/Transport/DataSender.cs
@@ -3,8 +3,8 @@
 
 #if !INTERNALIZE_TELEMETRY_SDK
 using Microsoft.Extensions.Configuration;
-#endif
 using Microsoft.Extensions.Logging;
+#endif
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -28,7 +28,7 @@ namespace NewRelic.Telemetry.Transport
         internal string UserAgent { get; private set; }
 
         protected readonly TelemetryConfiguration _config;
-        protected readonly TelemetryLogging _logger;
+        protected readonly ITelemetryLogger _logger;
 
         private readonly string _userAgentBase;
         private readonly HttpClient _httpClient;
@@ -51,23 +51,23 @@ namespace NewRelic.Telemetry.Transport
         }
 
         protected DataSender(IConfiguration configProvider, ILoggerFactory? loggerFactory)
-            : this(new TelemetryConfiguration(configProvider), loggerFactory)
+            : this(new TelemetryConfiguration(configProvider), new TelemetryLogging(loggerFactory), null)
+        {
+        }
+
+        protected DataSender(TelemetryConfiguration config, ILoggerFactory? loggerFactory)
+            : this(config, new TelemetryLogging(loggerFactory), null)
         {
         }
 #endif
 
-        protected DataSender(TelemetryConfiguration config)
-            : this(config, null)
-        {
-        }
-
-        protected DataSender(TelemetryConfiguration config, ILoggerFactory? loggerFactory, string? telemetrySdkVersionOverride = null)
+        protected DataSender(TelemetryConfiguration config, ITelemetryLogger logger, string? telemetrySdkVersionOverride)
         {
             _userAgentBase = $"{ProductInfo.Name}/{telemetrySdkVersionOverride ?? ProductInfo.Version}";
             UserAgent = _userAgentBase;
 
             _config = config;
-            _logger = new TelemetryLogging(loggerFactory);
+            _logger = logger;
 
             _httpClient = new HttpClient();
             _httpClient.Timeout = _config.SendTimeout;
@@ -78,7 +78,7 @@ namespace NewRelic.Telemetry.Transport
 
             _httpHandlerImpl = SendDataAsync;
         }
-       
+
         /// <summary>
         /// Method used to add product information including product name and version to the User-Agent HTTP header.
         /// </summary>

--- a/src/NewRelic.Telemetry/Transport/DataSender.cs
+++ b/src/NewRelic.Telemetry/Transport/DataSender.cs
@@ -27,8 +27,8 @@ namespace NewRelic.Telemetry.Transport
     {
         internal string UserAgent { get; private set; }
 
+        internal readonly ITelemetryLogger _logger;
         protected readonly TelemetryConfiguration _config;
-        protected readonly ITelemetryLogger _logger;
 
         private readonly string _userAgentBase;
         private readonly HttpClient _httpClient;
@@ -45,23 +45,23 @@ namespace NewRelic.Telemetry.Transport
         protected abstract bool ContainsNoData(TData dataToCheck);
 
 #if !INTERNALIZE_TELEMETRY_SDK
-        protected DataSender(IConfiguration configProvider)
+        internal DataSender(IConfiguration configProvider)
             : this(configProvider, null)
         {
         }
 
-        protected DataSender(IConfiguration configProvider, ILoggerFactory? loggerFactory)
+        internal DataSender(IConfiguration configProvider, ILoggerFactory? loggerFactory)
             : this(new TelemetryConfiguration(configProvider), new TelemetryLogging(loggerFactory), null)
         {
         }
 
-        protected DataSender(TelemetryConfiguration config, ILoggerFactory? loggerFactory)
+        internal DataSender(TelemetryConfiguration config, ILoggerFactory? loggerFactory)
             : this(config, new TelemetryLogging(loggerFactory), null)
         {
         }
 #endif
 
-        protected DataSender(TelemetryConfiguration config, ITelemetryLogger logger, string? telemetrySdkVersionOverride)
+        internal DataSender(TelemetryConfiguration config, ITelemetryLogger logger, string? telemetrySdkVersionOverride)
         {
             _userAgentBase = $"{ProductInfo.Name}/{telemetrySdkVersionOverride ?? ProductInfo.Version}";
             UserAgent = _userAgentBase;

--- a/tests/NewRelic.OpenTelemetry.Tests/SpanConverterTests.cs
+++ b/tests/NewRelic.OpenTelemetry.Tests/SpanConverterTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using NewRelic.OpenTelemetry.Internal;
 using NewRelic.Telemetry;
 using NewRelic.Telemetry.Tracing;
 using OpenTelemetry;
@@ -62,7 +63,7 @@ namespace NewRelic.OpenTelemetry.Tests
             {
                 ApiKey = "12345",
             };
-            var mockDataSender = new TraceDataSender(_options.TelemetryConfiguration, null);
+            var mockDataSender = new TraceDataSender(_options.TelemetryConfiguration, new SelfDiagnosticsLogger(), "mockexporter");
 
             // Capture the spans that were requested to be sent to New Relic.
             mockDataSender.WithCaptureSendDataAsyncDelegate((sb, retryId) =>

--- a/tests/NewRelic.OpenTelemetry.Tests/SpanConverterTests.cs
+++ b/tests/NewRelic.OpenTelemetry.Tests/SpanConverterTests.cs
@@ -83,7 +83,7 @@ namespace NewRelic.OpenTelemetry.Tests
                 return Task.FromResult(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK));
             });
 
-            var exporter = new NewRelicTraceExporter(mockDataSender, _options, null);
+            var exporter = new NewRelicTraceExporter(mockDataSender, _options, new SelfDiagnosticsLogger());
             var source = new ActivitySource("newrelic.test");
 
             using (var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()


### PR DESCRIPTION
The New Relic OTel exporter should leverage the same logging mechanism as the OTel SDK and Zipkin exporter is using.

The Telemetry SDK should continue to leverage ILogger for its logging.

Readme updates will be made in a separate PR.