### PR TITLE
Fix build warnings

### DIFF
--- a/examples/NewRelic.OpenTelemetry/AspNet/NewRelic.Examples.AspNet.csproj
+++ b/examples/NewRelic.OpenTelemetry/AspNet/NewRelic.Examples.AspNet.csproj
@@ -95,6 +95,9 @@
     <Reference Include="Microsoft.Extensions.Primitives, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Extensions.Primitives.2.1.0\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="OpenTelemetry, Version=1.0.0.1, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\OpenTelemetry.1.0.0-rc1.1\lib\net461\OpenTelemetry.dll</HintPath>
     </Reference>
@@ -145,9 +148,6 @@
     <Reference Include="System.EnterpriseServices" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System.Net.Http.Formatting">
       <HintPath>..\..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>

--- a/examples/NewRelic.OpenTelemetry/AspNet/Web.config
+++ b/examples/NewRelic.OpenTelemetry/AspNet/Web.config
@@ -257,7 +257,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed"/>
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>

--- a/examples/NewRelic.OpenTelemetry/AspNet/packages.config
+++ b/examples/NewRelic.OpenTelemetry/AspNet/packages.config
@@ -22,7 +22,7 @@
   <package id="Microsoft.Extensions.Options" version="2.1.0" targetFramework="net47" />
   <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="2.1.0" targetFramework="net47" />
   <package id="Microsoft.Extensions.Primitives" version="2.1.0" targetFramework="net47" />
-  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net47" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net47" />
   <package id="OpenTelemetry" version="1.0.0-rc1.1" targetFramework="net47" />
   <package id="OpenTelemetry.Api" version="1.0.0-rc1.1" targetFramework="net47" />
   <package id="OpenTelemetry.Instrumentation.AspNet" version="1.0.0-rc1.1" targetFramework="net47" />

--- a/examples/NewRelic.OpenTelemetry/AspNetCore/NewRelic.Examples.AspNetCore.csproj
+++ b/examples/NewRelic.OpenTelemetry/AspNetCore/NewRelic.Examples.AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/NewRelic.OpenTelemetry/AspNetCore/Properties/launchSettings.json
+++ b/examples/NewRelic.OpenTelemetry/AspNetCore/Properties/launchSettings.json
@@ -21,7 +21,7 @@
       "commandName": "Project",
       "launchBrowser": true,
       "launchUrl": "weatherforecast",
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/examples/NewRelic.OpenTelemetry/AspNetCore/Startup.cs
+++ b/examples/NewRelic.OpenTelemetry/AspNetCore/Startup.cs
@@ -50,8 +50,6 @@ namespace SampleAspNetCoreApp
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseHttpsRedirection();
-
             app.UseRouting();
 
             app.UseAuthorization();

--- a/examples/NewRelic.OpenTelemetry/ConsoleCore/NewRelic.Examples.ConsoleCore.csproj
+++ b/examples/NewRelic.OpenTelemetry/ConsoleCore/NewRelic.Examples.ConsoleCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc1.1" />
   </ItemGroup>
 

--- a/examples/NewRelic.Telemetry/AspNet/NewRelic.Examples.AspNet.csproj
+++ b/examples/NewRelic.Telemetry/AspNet/NewRelic.Examples.AspNet.csproj
@@ -101,7 +101,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+      <HintPath>..\..\..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />

--- a/examples/NewRelic.Telemetry/AspNet/NewRelic.Examples.AspNet.csproj
+++ b/examples/NewRelic.Telemetry/AspNet/NewRelic.Examples.AspNet.csproj
@@ -74,6 +74,9 @@
     <Reference Include="Microsoft.Extensions.Primitives, Version=3.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Extensions.Primitives.3.1.0\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Serilog.2.9.0\lib\net46\Serilog.dll</HintPath>
     </Reference>
@@ -121,9 +124,6 @@
     <Reference Include="System.EnterpriseServices" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System.Net.Http.Formatting">
       <HintPath>..\..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>

--- a/examples/NewRelic.Telemetry/AspNet/Web.config
+++ b/examples/NewRelic.Telemetry/AspNet/Web.config
@@ -249,7 +249,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed"/>
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>

--- a/examples/NewRelic.Telemetry/AspNet/packages.config
+++ b/examples/NewRelic.Telemetry/AspNet/packages.config
@@ -15,7 +15,7 @@
   <package id="Microsoft.Extensions.Logging.Abstractions" version="3.1.0" targetFramework="net47" />
   <package id="Microsoft.Extensions.Options" version="3.1.0" targetFramework="net47" />
   <package id="Microsoft.Extensions.Primitives" version="3.1.0" targetFramework="net47" />
-  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net47" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net47" />
   <package id="Serilog" version="2.9.0" targetFramework="net47" />
   <package id="Serilog.Extensions.Logging" version="3.0.1" targetFramework="net47" />
   <package id="Serilog.Settings.AppSettings" version="2.2.2" targetFramework="net47" />

--- a/examples/NewRelic.Telemetry/AspNetCore/NewRelic.Examples.AspNetCore.csproj
+++ b/examples/NewRelic.Telemetry/AspNetCore/NewRelic.Examples.AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/NewRelic.Telemetry/Console/NewRelic.Examples.Console.csproj
+++ b/examples/NewRelic.Telemetry/Console/NewRelic.Examples.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,9 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/NewRelic.OpenTelemetry.Tests/NewRelic.OpenTelemetry.Tests.csproj
+++ b/tests/NewRelic.OpenTelemetry.Tests/NewRelic.OpenTelemetry.Tests.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="OpenTelemetry" Version="1.0.0-rc1.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc1.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/NewRelic.OpenTelemetry.Tests/NewRelicExporterTests.cs
+++ b/tests/NewRelic.OpenTelemetry.Tests/NewRelicExporterTests.cs
@@ -58,7 +58,7 @@ namespace NewRelic.OpenTelemetry.Tests
                 };
 
                 Responses.TryAdd(
-                    Guid.Parse(context.Request.QueryString["requestId"]),
+                    Guid.Parse(context.Request.QueryString["requestId"] ?? string.Empty),
                     dictionary);
 
                 context.Response.OutputStream.Close();

--- a/tests/NewRelic.Telemetry.Tests/DataSenderTests.cs
+++ b/tests/NewRelic.Telemetry.Tests/DataSenderTests.cs
@@ -33,7 +33,7 @@ namespace NewRelic.Telemetry.Tests
         ///             F.  1/2 of Request C                    2 spans         --> OK
         ///             G.  1/2 of Request C                    2 spans         --> OK
         ///         --------------------------------------------------------------------------
-        ///             Total = 7 Requests/Batches              9 spans
+        ///             Total = 7 Requests/Batches              9 spans.
         /// </summary>
         [Fact]
         public async Task RequestTooLarge_SplitSuccess()
@@ -123,7 +123,7 @@ namespace NewRelic.Telemetry.Tests
         ///             F.  1/2 of Request C            TooLarge3                                   -->  Too Large (Can't Split)
         ///             G.  1/2 of Request C            OK                                          -->  Success
         ///         ----------------------------------------------------------------------------------------------------------------------
-        ///             Total = 7 Requests/Batches      4 spans requested, 1 span successful
+        ///             Total = 7 Requests/Batches      4 spans requested, 1 span successful.
         /// </summary>
         [Fact]
         public async Task RequestTooLarge_SplitFail()

--- a/tests/NewRelic.Telemetry.Tests/MetricBatchJsonTests.cs
+++ b/tests/NewRelic.Telemetry.Tests/MetricBatchJsonTests.cs
@@ -35,7 +35,7 @@ namespace NewRelic.Telemetry.Tests
             var jsonString = metricBatch.ToJson();
 
             // Assert
-            var resultMetricBatch = TestHelpers.DeserializeArrayFirstOrDefault(jsonString);
+            var resultMetricBatch = TestHelpers.DeserializeArrayFirst(jsonString);
             var resultCommonProps = TestHelpers.DeserializeObject(resultMetricBatch["common"]);
 
             TestHelpers.AssertForAttribValue(resultCommonProps, "timestamp", _timestampL);
@@ -85,7 +85,7 @@ namespace NewRelic.Telemetry.Tests
 
             TestHelpers.AssertForCollectionLength(resultMetrics, 2);
 
-            var countMetric = resultMetrics.FirstOrDefault();
+            var countMetric = resultMetrics.First();
 
             TestHelpers.AssertForAttribCount(countMetric, 5);
 

--- a/tests/NewRelic.Telemetry.Tests/NewRelic.Telemetry.Tests.csproj
+++ b/tests/NewRelic.Telemetry.Tests/NewRelic.Telemetry.Tests.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Description>Tests for .NET New Relic Telemetry SDK library</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/NewRelic.Telemetry.Tests/SpanBatchJsonTests.cs
+++ b/tests/NewRelic.Telemetry.Tests/SpanBatchJsonTests.cs
@@ -23,7 +23,7 @@ namespace NewRelic.Telemetry.Tests
             var jsonString = spanBatch.ToJson();
 
             // Assert
-            var resultSpanBatch = TestHelpers.DeserializeArrayFirstOrDefault(jsonString);
+            var resultSpanBatch = TestHelpers.DeserializeArrayFirst(jsonString);
             var resultCommonProps = TestHelpers.DeserializeObject(resultSpanBatch["common"]);
 
             TestHelpers.AssertForAttribValue(resultCommonProps, "trace.id", "traceId");
@@ -69,7 +69,7 @@ namespace NewRelic.Telemetry.Tests
 
             TestHelpers.AssertForCollectionLength(resultSpans, 1);
 
-            var resultSpan = resultSpans.FirstOrDefault();
+            var resultSpan = resultSpans.First();
 
             TestHelpers.AssertForAttribValue(resultSpan, "id", "span1");
             TestHelpers.AssertForAttribValue(resultSpan, "trace.id", "traceId");
@@ -237,7 +237,7 @@ namespace NewRelic.Telemetry.Tests
 
             TestHelpers.AssertForCollectionLength(resultSpans, 1);
 
-            var resultSpan = resultSpans.FirstOrDefault();
+            var resultSpan = resultSpans.First();
 
             TestHelpers.AssertForAttribValue(resultSpan, "id", "span1");
             TestHelpers.AssertForAttribValue(resultSpan, "trace.id", "traceId");

--- a/tests/NewRelic.Telemetry.Tests/TestHelpers.cs
+++ b/tests/NewRelic.Telemetry.Tests/TestHelpers.cs
@@ -14,35 +14,35 @@ namespace NewRelic.Telemetry.Tests
     {
         public static Dictionary<string, JsonElement>[] DeserializeArray(string jsonString)
         {
-            var items = JsonSerializer.Deserialize<JsonElement[]>(jsonString);
-            var objItems = items.Select(x => JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(x.ToString())).ToArray();
+            JsonElement[] items = JsonSerializer.Deserialize<JsonElement[]>(jsonString) ?? Array.Empty<JsonElement>();
+            var objItems = items.Select(x => JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(x.ToString() ?? string.Empty) ?? new Dictionary<string, JsonElement>()).ToArray();
 
             return objItems;
         }
 
         public static Dictionary<string, JsonElement>[] DeserializeArray(JsonElement jsonElem)
         {
-            return DeserializeArray(jsonElem.ToString());
+            return DeserializeArray(jsonElem.ToString() ?? string.Empty);
         }
 
-        public static Dictionary<string, JsonElement> DeserializeArrayFirstOrDefault(string jsonString)
+        public static Dictionary<string, JsonElement> DeserializeArrayFirst(string jsonString)
         {
-            return DeserializeArray(jsonString).FirstOrDefault();
+            return DeserializeArray(jsonString).First();
         }
 
-        public static Dictionary<string, JsonElement> DeserializeArrayFirstOrDefault(JsonElement jsonElem)
+        public static Dictionary<string, JsonElement>? DeserializeArrayFirstOrDefault(JsonElement jsonElem)
         {
             return DeserializeArray(jsonElem).FirstOrDefault();
         }
 
         public static Dictionary<string, JsonElement> DeserializeObject(string jsonString)
         {
-            return JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(jsonString);
+            return JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(jsonString) ?? new Dictionary<string, JsonElement>();
         }
 
         public static Dictionary<string, JsonElement> DeserializeObject(JsonElement jsonElem)
         {
-            return DeserializeObject(jsonElem.ToString());
+            return DeserializeObject(jsonElem.ToString() ?? string.Empty);
         }
 
         public static void AssertForCollectionLength(Dictionary<string, JsonElement>[] dic, int length)


### PR DESCRIPTION
Fixes the following build warnings:

- Nullable references
- Obsolete target frameworks by upgrading to .net 5
- Newtonsoft downgrades by updating references and binding redirects
- System.Numerics.Vector bad hint path