### PR TITLE
Test against more target frameworks

### DIFF
--- a/tests/NewRelic.OpenTelemetry.Tests/NewRelic.OpenTelemetry.Tests.csproj
+++ b/tests/NewRelic.OpenTelemetry.Tests/NewRelic.OpenTelemetry.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net452</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,6 +13,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/NewRelic.Telemetry.Tests/MetricBatchJsonTests.cs
+++ b/tests/NewRelic.Telemetry.Tests/MetricBatchJsonTests.cs
@@ -15,7 +15,12 @@ namespace NewRelic.Telemetry.Tests
 
         private readonly long _interval = 250L;
 
+        // Accounts for the different serialization behavior between the 2 Json libraries.
+#if NETFRAMEWORK
+        private readonly double _countValue = 67.0;
+#else
         private readonly long _countValue = 67;
+#endif
 
         private readonly NewRelicMetricSummaryValue _summaryValue = new NewRelicMetricSummaryValue(
             count: 10,

--- a/tests/NewRelic.Telemetry.Tests/NewRelic.Telemetry.Tests.csproj
+++ b/tests/NewRelic.Telemetry.Tests/NewRelic.Telemetry.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net461</TargetFrameworks>
     <Description>Tests for .NET New Relic Telemetry SDK library</Description>
   </PropertyGroup>
 
@@ -15,6 +15,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Runs our tests against the same frameworks that the nuget packages target.

For now the Telemetry SDK tests do not run against net45 because they rely on System.Text.Json so they will run against net461 instead.

The tests github action should already run the tests against all of the target frameworks.