### PR TITLE
Allow more retry attempts when creating a test listener

### DIFF
--- a/tests/NewRelic.OpenTelemetry.Tests/TestHttpServer.cs
+++ b/tests/NewRelic.OpenTelemetry.Tests/TestHttpServer.cs
@@ -18,7 +18,7 @@ namespace NewRelic.OpenTelemetry.Tests
             port = 0;
             RunningServer? server = null;
 
-            var retryCount = 100;
+            var retryCount = 5;
             while (retryCount > 0)
             {
                 try

--- a/tests/NewRelic.OpenTelemetry.Tests/TestHttpServer.cs
+++ b/tests/NewRelic.OpenTelemetry.Tests/TestHttpServer.cs
@@ -18,7 +18,7 @@ namespace NewRelic.OpenTelemetry.Tests
             port = 0;
             RunningServer? server = null;
 
-            var retryCount = 5;
+            var retryCount = 100;
             while (retryCount > 0)
             {
                 try

--- a/tests/NewRelic.OpenTelemetry.Tests/TestHttpServer.cs
+++ b/tests/NewRelic.OpenTelemetry.Tests/TestHttpServer.cs
@@ -23,7 +23,7 @@ namespace NewRelic.OpenTelemetry.Tests
             {
                 try
                 {
-                    port = _globalRandom.Next(2000, 5000);
+                    port = _globalRandom.Next(20000, 40000);
                     server = new RunningServer(action, host, port);
                     server.Start();
                     break;


### PR DESCRIPTION
When running the tests locally on a machine with multiple ports already in use, some of the tests that involve running a http listener on a port will fail to start that listener. Updating the random port range to 20000-40000 seems to make this problem less likely to occur.