### PR TITLE
Remove AuditLoggingEnabled exporter setting

### DIFF
--- a/examples/NewRelic.OpenTelemetry/ConsoleCore/Program.cs
+++ b/examples/NewRelic.OpenTelemetry/ConsoleCore/Program.cs
@@ -39,7 +39,6 @@ namespace SampleConsoleCoreApp
                 .AddNewRelicExporter(options =>
                 {
                     options.ApiKey = nrApiKey;
-                    options.AuditLoggingEnabled = true;
                 })
                 .AddHttpClientInstrumentation()
                 .Build())

--- a/src/NewRelic.OpenTelemetry/NewRelicExporterOptions.cs
+++ b/src/NewRelic.OpenTelemetry/NewRelicExporterOptions.cs
@@ -38,16 +38,6 @@ namespace NewRelic.OpenTelemetry
         }
 
         /// <summary>
-        /// Logs messages sent-to and received-by the New Relic endpoints.  This setting
-        /// is useful for troubleshooting, but is not recommended in production environments.
-        /// </summary>
-        public bool AuditLoggingEnabled
-        {
-            get => TelemetryConfiguration.AuditLoggingEnabled;
-            set => TelemetryConfiguration.AuditLoggingEnabled = value;
-        }
-
-        /// <summary>
         /// Gets or sets the export processor type to be used.
         /// </summary>
         public ExportProcessorType ExportProcessorType { get; set; } = ExportProcessorType.Batch;

--- a/src/NewRelic.OpenTelemetry/README.md
+++ b/src/NewRelic.OpenTelemetry/README.md
@@ -20,7 +20,6 @@ You can configure the exporter with the following options:
 
 * `ApiKey`: Your Insights Insert API key (required).
 * `Endpoint`: New Relic endpoint address.
-* `AuditLoggingEnabled`: Logs all data sent to New Relic.
 * `ExportProcessorType`: Whether the exporter should use
   [Batch or Simple exporting processor](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#built-in-span-processors). Defaults to the batch exporting processor which is recommended for most use cases.
 * `BatchExportProcessorOptions`: Configuration options for the batch exporter.


### PR DESCRIPTION
Removing the `AuditLoggingEnabled` setting until the requirements for this functionality is better defined. It will be easier to add in similar functionality later than it will be to modify any existing behavior that things are depending on.