### PR TITLE
Add github workflow to push to Nuget

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,72 @@
+name: Deploy packages to Nuget
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Run ID of the Workflow run that should be deployed.  ID can be found in URL for run.'
+        required: true
+      opentelemetry:
+        description: 'If "true", will push the OpenTelemetry Nuget package and symbols to Nuget. If "false", will not.'
+        required: true
+        default: 'false'
+      telemetrysdk:
+        description: 'If "true", will push the Telemetry SDK Nuget package and symbols to Nuget. If "false", will not.'
+        required: true
+        default: 'false'
+
+env:
+  telemetrysdk_path: ${{ github.workspace }}\NewRelic.Telemetry\bin\Release
+  exporter_path: ${{ github.workspace }}\NewRelic.OpenTelemetry\bin\Release
+  nuget_source: https://www.nuget.org
+
+jobs:
+
+  get-archive-deploy-packages:
+    name: Get, archive, and deploy packages
+    runs-on: windows-2019
+    steps:
+      - name: Download Deploy Artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: main.yml
+          run_id: ${{ github.event.inputs.run_id }}
+          name: my-artifact-${{ github.event.inputs.run_id }}
+          path: ${{ github.workspace }}
+          repo: ${{ github.repository }}
+      
+      - name: Archive OpenTelemetry Artifacts
+        if: ${{ github.event.inputs.opentelemetry == 'true' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: deploy-opentelemetry-artifacts-${{ github.run_id }}
+          path: ${{ env.exporter_path }}\*.*nupkg
+          if-no-files-found: error
+
+      - name: Archive Telemetry SDK Artifacts
+        if: ${{ github.event.inputs.telemetrysdk == 'true' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: deploy-telemetrysdk-artifacts-${{ github.run_id }}
+          path: ${{ env.telemetrysdk_path }}\*.*nupkg
+          if-no-files-found: error
+
+      - name: Setup Nuget Add to Path
+        uses: nuget/setup-nuget@v1.0.5
+        with:
+          nuget-version: '5.x' 
+
+      - name: Publish OpenTelemetry to Nuget
+        if: ${{ github.event.inputs.opentelemetry == 'true' }}
+        run: |
+          foreach ($file in Get-ChildItem -Path "${{ env.exporter_path }}\*" -File -Include *.nupkg) {
+            nuget push $file.fullname -ApiKey ${{ secrets.NUGET_APIKEY }} -Source ${{ env.nuget_source }} }
+        shell: powershell
+
+      - name: Publish Telemetry SDK to Nuget
+        if: ${{ github.event.inputs.telemetrysdk == 'true' }}
+        run: |
+          foreach ($file in Get-ChildItem -Path "${{ env.telemetrysdk_path }}\*" -File -Include *.nupkg) {
+            nuget push $file.fullname -ApiKey ${{ secrets.NUGET_APIKEY }} -Source ${{ env.nuget_source }} }
+        shell: powershell


### PR DESCRIPTION
This adds a manually triggered workflow that allows us to conditionally push either or both of the OpenTelemetry and Telemetry SDK Nuget packages to Nuget.

For whatever reason pushing the packages to Myget causes the packages to fail these validation checks, so pushing the packages to Nuget via Myget will cause our packages pulled from Nuget to fail these validations too. Adding this deployment workflow allows our Nuget packages to continue to pass the Nuget Package Explorer validation checks. 