### PR TITLE
Weak access modifiers for NewRelicExporterOptions and NewRelicTraceExporter

### DIFF
--- a/src/NewRelic.OpenTelemetry/NewRelicExporterOptions.cs
+++ b/src/NewRelic.OpenTelemetry/NewRelicExporterOptions.cs
@@ -13,10 +13,6 @@ namespace NewRelic.OpenTelemetry
     /// </summary>
     public class NewRelicExporterOptions
     {
-        internal NewRelicExporterOptions()
-        {
-        }
-
         /// <summary>
         /// REQUIRED: Your Insights Insert API Key.  This value is required in order to communicate with the
         /// New Relic Endpoint. 

--- a/src/NewRelic.OpenTelemetry/NewRelicTraceExporter.cs
+++ b/src/NewRelic.OpenTelemetry/NewRelicTraceExporter.cs
@@ -20,7 +20,7 @@ namespace NewRelic.OpenTelemetry
     /// <summary>
     /// An exporter used to send Trace/Span information to New Relic.
     /// </summary>
-    internal class NewRelicTraceExporter : BaseExporter<Activity>
+    public class NewRelicTraceExporter : BaseExporter<Activity>
     {
         private const string OTelStatusCodeAttributeName = "otel.status_code";
         private const string OTelStatusDescriptionAttributeName = "otel.status_description";


### PR DESCRIPTION
At the moment users can add NewRelic exporter through the `NewRelicExporterHelperExtensions.AddNewRelicExporter` method only. Since NewRelicExporterOptions and NewRelicTraceExporter classes couldn't be initialized outside the assembly.

Propose to make them public. This way user can save the reference to the processor somewhere and use the processor's public API. For example, method `ForceFlush`.

I noticed how it was done in the default exporters — [Jaeger](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Exporter.Jaeger) and [Zipkin](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Exporter.Zipkin) exporters are public.