### PR TITLE
Change readme to indicate in process of archiving

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ❗Notice: This project is in the process of being archived as is and is no longer actively maintained.
 
-Rather than developing a .NET specific OpenTelemetry SDK and .NET specific OpenTelemetry exporter, New Relic has adopted a language agnostic approach that facilitates data collection from all OpenTelemetry data sources.
+New Relic has adopted a language agnostic approach that facilitates data collection from all OpenTelemetry data sources.  We are deprecating the support of the .NET Telemetry SDK and the .NET OpenTelemetry exporter. 
 
 The current recommended approaches for sending OpenTelemetry data to the New Relic platform are as follows:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 [![Community Project header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Project.png)](https://opensource.newrelic.com/oss-category/#community-project)
 
+❗Notice: This project is in the process of being archived as is and is no longer actively maintained.
+
+Rather than developing a .NET specific OpenTelemetry exporter New Relic has adopted a language agnostic approach that facilitates data collection from all OpenTelemetry data sources.
+
+The current recommended approaches for sending OpenTelemetry data to the New Relic platform are as follows:
+
+* Configure your OpenTelemetry data source to send data to the [OpenTelemetry Collector](https://docs.newrelic.com/docs/integrations/open-source-telemetry-integrations/opentelemetry/introduction-opentelemetry-new-relic/#collector) using the OpenTelemetry Protocol (OTLP) and configure the collector to forward the data using the [New Relic collector exporter](https://github.com/newrelic-forks/opentelemetry-collector-contrib/tree/newrelic-main/exporter/newrelicexporter).
+* Configure your OpenTelemetry data source to send data to the native OpenTelemetry Protocol (OTLP) data ingestion endpoint. [OTLP](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md) is an open source gRPC based protocol for sending telemetry data. The protocol is vendor agnostic and open source.
+
+For more details please see:
+* [OpenTelemetry quick start](https://docs.newrelic.com/docs/integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-quick-start/)
+* [Introduction to OpenTelemetry with New Relic](https://docs.newrelic.com/docs/integrations/open-source-telemetry-integrations/opentelemetry/introduction-opentelemetry-new-relic/)
+* [Native OpenTelemetry Protocol (OTLP) support](https://docs.newrelic.com/whats-new/2021/04/native-support-opentelemetry/)
 
 # New Relic .NET Telemetry SDK
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ❗Notice: This project is in the process of being archived as is and is no longer actively maintained.
 
-Rather than developing a .NET specific OpenTelemetry exporter New Relic has adopted a language agnostic approach that facilitates data collection from all OpenTelemetry data sources.
+Rather than developing a .NET specific OpenTelemetry SDK and .NET specific OpenTelemetry exporter, New Relic has adopted a language agnostic approach that facilitates data collection from all OpenTelemetry data sources.
 
 The current recommended approaches for sending OpenTelemetry data to the New Relic platform are as follows:
 


### PR DESCRIPTION
To indicate to the community that the repo is in the process of archival.  All other agents have either archived or added a note to indicate that intention.